### PR TITLE
chores/rubocop reduce complexity #160158784

### DIFF
--- a/app/javascript/components/lease_ups/LeaseUpApplicationsTable.js
+++ b/app/javascript/components/lease_ups/LeaseUpApplicationsTable.js
@@ -68,7 +68,7 @@ const LeaseUpApplicationsTable = ({ listingId, dataSet, onLeaseUpStatusChange, o
       { Header: 'Phone',              accessor: 'phone' ,             Cell: resizableCell, className: 'text-left' },
       { Header: 'Email',              accessor: 'email' ,             Cell: resizableCell, className: 'text-left' },
       { Header: 'Address',            accessor: 'address',            Cell: resizableCell, className: 'text-left' },
-      { Header: 'Status Updated',     accessor: 'status_updated' ,    headerClassName: 'td-offset-right text-right', Cell: cellFormat.date },
+      { Header: 'Status Updated',     accessor: 'status_last_updated' ,    headerClassName: 'td-offset-right text-right', Cell: cellFormat.date },
       { Header: 'Lease Up Status',    accessor: 'lease_up_status',    headerClassName: 'td-min-wide tr-fixed-right', Cell: cell => <LeaseUpStatusCell cell={cell} onChange={onLeaseUpStatusChange} applicationId={cell.original.id}/> }
     ]
 
@@ -81,7 +81,7 @@ const LeaseUpApplicationsTable = ({ listingId, dataSet, onLeaseUpStatusChange, o
     } else if (column.id !== 'application_number') {
       attrs.onClick = (e, handleOriginal) => { if (rowInfo) onCellClick(listingId, rowInfo) }
 
-      if (column.id === 'status_updated') {
+      if (column.id === 'status_last_updated') {
         attrs.className = 'td-offset-right text-right'
       } else if (column.id === 'rankOrder') {
         attrs.className = 'td-min-narrow'

--- a/app/javascript/components/lease_ups/leaseUpModel.js
+++ b/app/javascript/components/lease_ups/leaseUpModel.js
@@ -14,7 +14,7 @@ export const buildLeaseUpModel = (applicationPreference) => {
     mailing_address: applicant.mailing_address,
     residence_address: applicant.residence_address,
     lease_up_status: application.processing_status,
-    status_updated: applicationPreference.last_modified_date,
+    status_last_updated: application.status_last_updated,
     preference_order: applicationPreference.preference_order,
     preference_record_type: listingPreference.record_type_for_app_preferences,
     preference_lottery_rank: applicationPreference.preference_lottery_rank,

--- a/app/javascript/components/mappers/soqlToDomain/application.js
+++ b/app/javascript/components/mappers/soqlToDomain/application.js
@@ -46,6 +46,7 @@ export const mapApplication = (a) => {
     terms_acknowledged: a.Terms_Acknowledged,
     number_of_dependents: a.Number_of_Dependents,
     processing_status: a.Processing_Status,
+    status_last_updated: a.Status_Last_Updated,
     reserved_senior: a.Reserved_Senior
   }
 }

--- a/app/javascript/components/mappers/soqlToDomain/application_preference.js
+++ b/app/javascript/components/mappers/soqlToDomain/application_preference.js
@@ -32,7 +32,6 @@ export const mapApplicationPreference = (value) => {
     zip_code: value.Zip_Code,
     street: value.Street,
     recordtype_developername: get(value,'RecordType.DeveloperName'),
-    last_modified_date: value.LastModifiedDate,
     total_household_rent: String(value.Total_Household_Rent)
   }
 }

--- a/app/services/force/base.rb
+++ b/app/services/force/base.rb
@@ -104,16 +104,6 @@ module Force
       self.class.fields["#{type}_fields"].keys.join(', ')
     end
 
-    def parse_results_for_fields(results, type)
-      parse_results(results, self.class.fields["#{type}_fields"])
-    end
-
-    # Extracted out for clarity
-    # This is being used in services. should be refactored
-    def parse_results(results, fields)
-      Force::Responses.parse_results(results, fields)
-    end
-
     # Extracted out for clarity
     # This is being used in services. should be refactored
     def massage(h)

--- a/app/services/force/lease_up_service.rb
+++ b/app/services/force/lease_up_service.rb
@@ -40,8 +40,8 @@ module Force
     def set_status_last_updated(status_last_updated_dates, application_data)
       status_last_updated_dates.each do |status_date|
         application_data.each do |app_data|
-          if app_data[:Application] == status_date[:Application]
-            app_data[:Status_Last_Updated] = status_date[:Status_Last_Updated]
+          if app_data[:Application][:Id] == status_date[:Application]
+            app_data[:Application][:Status_Last_Updated] = status_date[:Status_Last_Updated]
             break
           end
         end
@@ -49,15 +49,12 @@ module Force
     end
 
     def find_status_last_updated_dates(application_ids)
-      parse_results(
-        query(%(
-          SELECT MAX(Processing_Date_Updated__c) Status_Last_Updated, Application__c
-          FROM Field_Update_Comment__c
-          WHERE Application__c IN (#{application_ids.join(', ')})
-          GROUP BY Application__c
-        )),
-        Hashie::Mash.new(Application__c: nil, Status_Last_Updated: nil),
-      )
+      massage(query(%(
+        SELECT MAX(Processing_Date_Updated__c) Status_Last_Updated, Application__c
+        FROM Field_Update_Comment__c
+        WHERE Application__c IN (#{application_ids.join(', ')})
+        GROUP BY Application__c
+      )))
     end
 
     def user_can_access

--- a/app/services/force/responses.rb
+++ b/app/services/force/responses.rb
@@ -27,35 +27,5 @@ module Force
       # calls .to_s so it works for symbols too
       str.to_s.gsub('__c', '').gsub('__r', '')
     end
-
-    def self.parse_results(results, fields)
-      results.map do |result|
-        parsed_object(result, fields)
-      end
-    end
-
-    def self.parsed_object(result, fields)
-      obj = {}
-      fields.each do |field, attrs|
-        val = nil
-        if field.include? '.'
-          parts = field.split('.')
-          if parts.count == 3
-            val = result[parts[0]].try(:[], parts[1]).try(:[], parts[2])
-          else
-            val = result[parts.first] ? result[parts.first][parts.last] : nil
-          end
-        elsif result[field]
-          if attrs && attrs.type == 'date' && result[field]
-            val = Date.parse(result[field]).strftime('%D')
-          else
-            val = result[field]
-          end
-        end
-        obj[field] = val
-      end
-      Hashie::Mash.new(massage(obj))
-    end
-
   end
 end

--- a/spec/javascript/components/lease_ups/LeaseUpsPage.test.js
+++ b/spec/javascript/components/lease_ups/LeaseUpsPage.test.js
@@ -40,7 +40,6 @@ describe('LeaseUpApplicationsPage', () => {
 
   test('Should render LeaseUpTable', () => {
     const applications = [ buildApplicationPreference(1), buildApplicationPreference(2) ]
-    console.log("PLEASE LOG THIS", applications)
     const wrapper = renderer.create(
       <LeaseUpApplicationsPage listing={listings} applications={applications} />,
     )

--- a/spec/javascript/components/lease_ups/LeaseUpsPage.test.js
+++ b/spec/javascript/components/lease_ups/LeaseUpsPage.test.js
@@ -8,7 +8,6 @@ const buildApplicationPreference = (uniqId, attributes = {}) => {
   return merge({
     "Id": uniqId,
     "Processing_Status": 'processing',
-    'LastModifiedDate': '2018-04-26T12:31:39.000+0000',
     'Preference_Order': '1',
     'Preference_Lottery_Rank': '1',
     'Listing_Preference_ID': {
@@ -17,6 +16,7 @@ const buildApplicationPreference = (uniqId, attributes = {}) => {
     "Application" : {
       "Id": 1000 + uniqId,
       "Name": `Application Name ${uniqId}`,
+      'Status_Last_Updated': '2018-04-26T12:31:39.000+0000',
       "Applicant": {
         "Id": '1',
         "Residence_Address": `1316 BURNETT ${uniqId}`,
@@ -40,7 +40,7 @@ describe('LeaseUpApplicationsPage', () => {
 
   test('Should render LeaseUpTable', () => {
     const applications = [ buildApplicationPreference(1), buildApplicationPreference(2) ]
-
+    console.log("PLEASE LOG THIS", applications)
     const wrapper = renderer.create(
       <LeaseUpApplicationsPage listing={listings} applications={applications} />,
     )


### PR DESCRIPTION
Note: This PR actually fixes a bug where lease up status update date field was not pulling from the correct place in the salesforce object in addition to fixing the issue of rubocop reporting a function with too high a complexity. 
https://www.pivotaltracker.com/story/show/160158784