### PR TITLE
chores/lint exclude public dir #160487182

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     ]
   },
   "standard": {
-    "ignore": ["./node_modules/**/*", "./spec/javascript/fixtures/*", "app/assets/javascripts/cable.js"],
+    "ignore": ["./node_modules/**/*", "./spec/javascript/fixtures/*", "app/assets/javascripts/cable.js", "public/**/*"],
     "env": [ "jest" ],
     "parser": "babel-eslint"
   }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/160487182

after this is merged, we'll be able to add yarn lint back to the semaphore job.

See this build for proof that it works:
 https://semaphoreci.com/exygy/sf-dahlia-lap/branches/chores-lint-exclude-public-dir-160487182/builds/2