### PR TITLE
Features/lease salesforce saving #158157958

### DIFF
--- a/app/controllers/api/v1/short_form_controller.rb
+++ b/app/controllers/api/v1/short_form_controller.rb
@@ -49,6 +49,7 @@ class Api::V1::ShortFormController < ApiController
             lease: %i[
               id
               unit
+              leaseStatus
               leaseStartDate
               monthlyParkingRent
               totalMonthlyRentWithoutParking

--- a/app/controllers/api/v1/short_form_controller.rb
+++ b/app/controllers/api/v1/short_form_controller.rb
@@ -6,12 +6,10 @@ class Api::V1::ShortFormController < ApiController
     logger.debug "application_api_params: #{application_api_params}"
     short_form_validator = ShortFormValidator.new(application_api_params)
     if short_form_validator.valid?
-      # If lease information is available, submit it separately.
       if application_api_params.key?(:lease)
         response = lease_service.submit_lease(application_api_params[:lease],
                                               application_api_params[:id],
                                               application_api_params[:primaryApplicantContact])
-        # Don't submit lease application_api_params to the customAPI.
         logger.debug "lease submit response: #{response}"
       end
       application = application_service.submit(application_api_params)

--- a/app/controllers/api/v1/short_form_controller.rb
+++ b/app/controllers/api/v1/short_form_controller.rb
@@ -45,6 +45,14 @@ class Api::V1::ShortFormController < ApiController
             :numberOfDependents,
             :formMetadata,
             :hasSenior,
+            lease: %i[
+              id
+              unit
+              leaseStartDate
+              monthlyParkingRent
+              totalMonthlyRentWithoutParking
+              monthlyTenantContribution
+            ],
             primaryApplicant: %i[
               contactId
               appMemberId

--- a/app/controllers/api/v1/short_form_controller.rb
+++ b/app/controllers/api/v1/short_form_controller.rb
@@ -6,6 +6,14 @@ class Api::V1::ShortFormController < ApiController
     logger.debug "application_api_params: #{application_api_params}"
     short_form_validator = ShortFormValidator.new(application_api_params)
     if short_form_validator.valid?
+      # If lease information is available, submit it separately.
+      if application_api_params.key?(:lease)
+        response = lease_service.submit_lease(application_api_params[:lease],
+                                              application_api_params[:id],
+                                              application_api_params[:primaryApplicantContact])
+        # Don't submit lease application_api_params to the customAPI.
+        logger.debug "lease submit response: #{response}"
+      end
       application = application_service.submit(application_api_params)
       logger.debug "application submit response: #{application}"
       render json: { application: application }
@@ -166,5 +174,9 @@ class Api::V1::ShortFormController < ApiController
 
   def application_service
     Force::ApplicationService.new(current_user)
+  end
+
+  def lease_service
+    Force::LeaseService.new(current_user)
   end
 end

--- a/app/controllers/api/v1/short_form_controller.rb
+++ b/app/controllers/api/v1/short_form_controller.rb
@@ -45,6 +45,7 @@ class Api::V1::ShortFormController < ApiController
             :numberOfDependents,
             :formMetadata,
             :hasSenior,
+            :primaryApplicantContact,
             lease: %i[
               id
               unit

--- a/app/javascript/components/mappers/domainToApi/application.js
+++ b/app/javascript/components/mappers/domainToApi/application.js
@@ -18,6 +18,7 @@ const mapAdaPrioritiesMap = (list) => {
 
 export const applicationFieldMapper = {
   id: 'id',
+  primary_applicant_contact: 'primaryApplicantContact',
   application_language: 'applicationLanguage',
   has_military_service: 'hasMilitaryService',
   has_developmental_disability: 'hasDevelopmentalDisability',

--- a/app/javascript/components/mappers/domainToApi/applicationShape.js
+++ b/app/javascript/components/mappers/domainToApi/applicationShape.js
@@ -5,12 +5,14 @@ import { preferenceFieldMapper } from './preference'
 import { householdMembersFieldMapper } from './householdMember'
 import { alternateContactFieldMapper } from './alternateContact'
 import { demographicsFieldMapper } from './demographics'
+import { leaseFieldMapper } from './lease'
 
 export const applicationShape = {
   ...applicationFieldMapper,
   listingID: (source) => source.listing.id,
   alternateContact: shapeMapper('alternate_contact', alternateContactFieldMapper),
   demographics: shapeMapper('demographics', demographicsFieldMapper),
+  lease: shapeMapper('lease', leaseFieldMapper),
   ...{
     primaryApplicant: shapeMapper('applicant', applicantFieldMapper),
     shortFormPreferences: listMapper('preferences', preferenceFieldMapper),
@@ -24,6 +26,7 @@ export const buildApplicationShape = application => {
     [
       'alternateContact',
       'adaPrioritiesSelected',
-      'demographics'
+      'demographics',
+      'lease'
     ])
 }

--- a/app/javascript/components/mappers/domainToApi/lease.js
+++ b/app/javascript/components/mappers/domainToApi/lease.js
@@ -4,7 +4,7 @@ export const leaseFieldMapper = {
   id: 'id',
   unit: 'unit',
   lease_start_date: 'leaseStartDate',
-  monthly_parking_rent: 'monthlyParingRent',
+  monthly_parking_rent: 'monthlyParkingRent',
   total_monthly_rent_without_parking: 'totalMonthlyRentWithoutParking',
   monthly_tenant_contribution: 'monthlyTenantContribution'
   // TODO: add lease status, app id? contact id?

--- a/app/javascript/components/mappers/domainToApi/lease.js
+++ b/app/javascript/components/mappers/domainToApi/lease.js
@@ -1,0 +1,13 @@
+import { createFieldMapper } from '~/utils/objectUtils'
+
+export const leaseFieldMapper = {
+  id: 'id',
+  unit: 'unit',
+  lease_start_date: 'leaseStartDate',
+  monthly_parking_rent: 'monthlyParingRent',
+  total_monthly_rent_without_parking: 'totalMonthlyRentWithoutParking',
+  monthly_tenant_contribution: 'monthlyTenantContribution'
+  // TODO: add lease status, app id? contact id?
+}
+
+export const mapLease = createFieldMapper(leaseFieldMapper)

--- a/app/javascript/components/mappers/domainToApi/lease.js
+++ b/app/javascript/components/mappers/domainToApi/lease.js
@@ -3,11 +3,11 @@ import { createFieldMapper } from '~/utils/objectUtils'
 export const leaseFieldMapper = {
   id: 'id',
   unit: 'unit',
+  lease_status: 'leaseStatus',
   lease_start_date: 'leaseStartDate',
   monthly_parking_rent: 'monthlyParkingRent',
   total_monthly_rent_without_parking: 'totalMonthlyRentWithoutParking',
   monthly_tenant_contribution: 'monthlyTenantContribution'
-  // TODO: add lease status, app id? contact id?
 }
 
 export const mapLease = createFieldMapper(leaseFieldMapper)

--- a/app/javascript/components/mappers/soqlToDomain/application.js
+++ b/app/javascript/components/mappers/soqlToDomain/application.js
@@ -15,6 +15,7 @@ export const mapApplication = (a) => {
   console.log('Application before being mapped to domain', a)
   return {
     applicant: mapShape(mapApplicationMember, a.Applicant),
+    primary_applicant_contact: a.Primary_Applicant,
     alternate_contact: mapShape(mapApplicationMember, a.Alternate_Contact),
     listing: mapShape(mapListing, a.Listing),
     preferences: mapList(mapApplicationPreference, a.preferences),

--- a/app/javascript/components/mappers/soqlToDomain/application.js
+++ b/app/javascript/components/mappers/soqlToDomain/application.js
@@ -12,7 +12,6 @@ const parseList = text => split(text, ';')
 const toChecklist = list => fromPairs(list.map(i => [snakeCase(i), true]))
 
 export const mapApplication = (a) => {
-  console.log('Application before being mapped to domain', a)
   return {
     applicant: mapShape(mapApplicationMember, a.Applicant),
     primary_applicant_contact: a.Primary_Applicant,

--- a/app/javascript/components/mappers/soqlToDomain/application.js
+++ b/app/javascript/components/mappers/soqlToDomain/application.js
@@ -12,6 +12,7 @@ const parseList = text => split(text, ';')
 const toChecklist = list => fromPairs(list.map(i => [snakeCase(i), true]))
 
 export const mapApplication = (a) => {
+  console.log('Application before being mapped to domain', a)
   return {
     applicant: mapShape(mapApplicationMember, a.Applicant),
     alternate_contact: mapShape(mapApplicationMember, a.Alternate_Contact),

--- a/app/javascript/components/mappers/soqlToDomain/lease.js
+++ b/app/javascript/components/mappers/soqlToDomain/lease.js
@@ -2,6 +2,7 @@ export const mapLease = (lease) => {
   return {
     id: lease.Id,
     unit: lease.Unit,
+    lease_status: lease.Lease_Status,
     lease_start_date: lease.Lease_Start_Date,
     monthly_parking_rent: lease.Monthly_Parking_Rent,
     total_monthly_rent_without_parking: lease.Total_Monthly_Rent_without_Parking,

--- a/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
+++ b/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
@@ -54,14 +54,14 @@ class SupplementalApplicationPage extends React.Component {
     const synchedApplication = cloneDeep(application)
 
     // Monthly rent and preferences are only updated in handleSavePreference below.
-    // We set this values so we keep whaterver we save in the panels
+    // We set this values so we keep whatever we save in the panels
     synchedApplication.total_monthly_rent = persistedApplication.total_monthly_rent
     synchedApplication.preferences = cloneDeep(persistedApplication.preferences)
 
     await updateApplicationAction(synchedApplication)
     this.setState({ persistedApplication: synchedApplication })
-    // Redirect to same page to be able to re-pull data from SalesForce
-    window.location.href = appPaths.toApplicationSupplementals(application.id)
+    // Reload the page to be pull updated data from SalesForce.
+    window.location.reload()
   }
 
   handleSavePreference = async (preferenceIndex, application) => {

--- a/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
+++ b/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
@@ -60,6 +60,8 @@ class SupplementalApplicationPage extends React.Component {
 
     await updateApplicationAction(synchedApplication)
     this.setState({ persistedApplication: synchedApplication })
+    // Redirect to same page to be able to re-pull data from SalesForce
+    window.location.href = appPaths.toApplicationSupplementals(application.id)
   }
 
   handleSavePreference = async (preferenceIndex, application) => {

--- a/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
+++ b/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
@@ -58,10 +58,12 @@ class SupplementalApplicationPage extends React.Component {
     synchedApplication.total_monthly_rent = persistedApplication.total_monthly_rent
     synchedApplication.preferences = cloneDeep(persistedApplication.preferences)
 
-    await updateApplicationAction(synchedApplication)
+    const response = await updateApplicationAction(synchedApplication)
     this.setState({ persistedApplication: synchedApplication })
-    // Reload the page to be pull updated data from SalesForce.
-    window.location.reload()
+    if (response !== false) {
+      // Reload the page to be pull updated data from SalesForce.
+      window.location.reload()
+    }
   }
 
   handleSavePreference = async (preferenceIndex, application) => {

--- a/app/javascript/components/supplemental_application/actions.js
+++ b/app/javascript/components/supplemental_application/actions.js
@@ -3,8 +3,9 @@ import domainToApi from '~/components/mappers/domainToApi'
 import Alerts from '~/components/Alerts'
 
 export const updateApplicationAction = async (application) => {
+  console.log('Application before API format', application)
   const applicationApi = domainToApi.buildApplicationShape(application)
-
+  console.log('Application API format', applicationApi)
   const response = await apiService.submitApplication(applicationApi)
   if (response === false) {
     Alerts.error()

--- a/app/javascript/components/supplemental_application/actions.js
+++ b/app/javascript/components/supplemental_application/actions.js
@@ -3,9 +3,7 @@ import domainToApi from '~/components/mappers/domainToApi'
 import Alerts from '~/components/Alerts'
 
 export const updateApplicationAction = async (application) => {
-  console.log('Application before API format', application)
   const applicationApi = domainToApi.buildApplicationShape(application)
-  console.log('Application API format', applicationApi)
   const response = await apiService.submitApplication(applicationApi)
   if (response === false) {
     Alerts.error()

--- a/app/javascript/components/supplemental_application/sections/LeaseInformatonInputs.js
+++ b/app/javascript/components/supplemental_application/sections/LeaseInformatonInputs.js
@@ -37,6 +37,7 @@ const LeaseInformationInputs = ({ formApi, store }) => {
   const { availableUnits } = store
   const availableUnitsOptions = formUtils.toOptions(map(availableUnits, pluck('id', 'unit_number')))
   const totalMonthlyRent = getTotalMonthlyRent(formApi.values)
+  console.log('FORM API VALUES Lease info', formApi.values)
   return (
     <React.Fragment>
       <FormGrid.Row paddingBottom>

--- a/app/javascript/components/supplemental_application/sections/LeaseInformatonInputs.js
+++ b/app/javascript/components/supplemental_application/sections/LeaseInformatonInputs.js
@@ -37,7 +37,6 @@ const LeaseInformationInputs = ({ formApi, store }) => {
   const { availableUnits } = store
   const availableUnitsOptions = formUtils.toOptions(map(availableUnits, pluck('id', 'unit_number')))
   const totalMonthlyRent = getTotalMonthlyRent(formApi.values)
-  console.log('FORM API VALUES Lease info', formApi.values)
   return (
     <React.Fragment>
       <FormGrid.Row paddingBottom>

--- a/app/services/force/application_service.rb
+++ b/app/services/force/application_service.rb
@@ -80,7 +80,7 @@ module Force
       # if lease information is present, pop it out and submit it separately.
       if data.key?(:lease)
         # submit lease. Need to manipulate it and get other values too (e.g. app id, primary applicant contact id. where should I get those?
-        submit_lease(data[:lease], data[:id], data[:primaryApplicant][:id])
+        submit_lease(data[:lease], data[:id], data[:primaryApplicantContact])
         # delete it from the map
         data = data.except(:lease)
       end
@@ -90,28 +90,28 @@ module Force
     def submit_lease(lease, application_id, primary_contact_id)
       puts 'PRIMARY CONTACT ID', primary_contact_id
       # Update
-      # TODO: add primary applicant contact, application id.
+      # TODO: add lease status, fix Tenant__c permissions.
       if lease[:id]
-        response = @client.update('Lease__c',
-                                  Id: lease[:id],
-                                  Tenant__c: primary_contact_id,
-                                  Unit__c: lease[:unit],
-                                  Lease_Start_Date__c: lease[:leaseStartDate],
-                                  Monthly_Parking_Rent__c: lease[:monthlyParkingRent],
-                                  Total_Monthly_Rent_without_Parking__c: lease[:totalMonthlyRentWithoutParking],
-                                  Monthly_Tenant_Contribution__c: lease[:monthlyTenantContribution])
+        response = @client.update!('Lease__c',
+                                   Id: lease[:id],
+                                   # Tenant__c: primary_contact_id,
+                                   Unit__c: lease[:unit],
+                                   Lease_Start_Date__c: lease[:leaseStartDate],
+                                   Monthly_Parking_Rent__c: lease[:monthlyParkingRent],
+                                   Total_Monthly_Rent_without_Parking__c: lease[:totalMonthlyRentWithoutParking],
+                                   Monthly_Tenant_Contribution__c: lease[:monthlyTenantContribution])
         puts 'Successfully Updated Lease Information: ', response
       else
         # Create
         # Tenant__c: primary_contact_id
-        response = @client.create('Lease__c',
-                                  Application__c: application_id,
-                                  Tenant__c: primary_contact_id,
-                                  Unit__c: lease[:unit],
-                                  Lease_Start_Date__c: lease[:leaseStartDate],
-                                  Monthly_Parking_Rent__c: lease[:monthlyParkingRent],
-                                  Total_Monthly_Rent_without_Parking__c: lease[:totalMonthlyRentWithoutParking],
-                                  Monthly_Tenant_Contribution__c: lease[:monthlyTenantContribution])
+        response = @client.create!('Lease__c',
+                                   Application__c: application_id,
+                                   # Tenant__c: primary_contact_id,
+                                   Unit__c: lease[:unit],
+                                   Lease_Start_Date__c: lease[:leaseStartDate],
+                                   Monthly_Parking_Rent__c: lease[:monthlyParkingRent],
+                                   Total_Monthly_Rent_without_Parking__c: lease[:totalMonthlyRentWithoutParking],
+                                   Monthly_Tenant_Contribution__c: lease[:monthlyTenantContribution])
         puts 'Successfully created new lease: ', response
       end
     end

--- a/app/services/force/lease_service.rb
+++ b/app/services/force/lease_service.rb
@@ -17,32 +17,41 @@ module Force
              .first
     end
 
-    def submit_lease(lease, application_id, _primary_contact_id)
-      # Update
+    def submit_lease(lease, application_id, primary_contact_id)
       # FIXME: Fix Tenant__c permissions so we can submit these values.
       if lease[:id]
-        response = @client.update!('Lease__c',
-                                   Id: lease[:id],
-                                   # Tenant__c: primary_contact_id,
-                                   Unit__c: lease[:unit],
-                                   Lease_Status__c: lease[:leaseStatus],
-                                   Lease_Start_Date__c: lease[:leaseStartDate],
-                                   Monthly_Parking_Rent__c: lease[:monthlyParkingRent],
-                                   Total_Monthly_Rent_without_Parking__c: lease[:totalMonthlyRentWithoutParking],
-                                   Monthly_Tenant_Contribution__c: lease[:monthlyTenantContribution])
+        response = update_lease(lease, application_id, primary_contact_id)
       else
-        # Create
-        response = @client.create!('Lease__c',
-                                   Application__c: application_id,
-                                   # Tenant__c: primary_contact_id,
-                                   Unit__c: lease[:unit],
-                                   Lease_Status__c: 'Draft',
-                                   Lease_Start_Date__c: lease[:leaseStartDate],
-                                   Monthly_Parking_Rent__c: lease[:monthlyParkingRent],
-                                   Total_Monthly_Rent_without_Parking__c: lease[:totalMonthlyRentWithoutParking],
-                                   Monthly_Tenant_Contribution__c: lease[:monthlyTenantContribution])
+        response = create_lease(lease, application_id, primary_contact_id)
       end
       response
+    end
+
+    private
+
+    def create_lease(lease, application_id, _primary_contact_id)
+      @client.create!('Lease__c',
+                      Application__c: application_id,
+                      # Tenant__c: primary_contact_id,
+                      Unit__c: lease[:unit],
+                      Lease_Status__c: 'Draft',
+                      Lease_Start_Date__c: lease[:leaseStartDate],
+                      Monthly_Parking_Rent__c: lease[:monthlyParkingRent],
+                      Total_Monthly_Rent_without_Parking__c: lease[:totalMonthlyRentWithoutParking],
+                      Monthly_Tenant_Contribution__c: lease[:monthlyTenantContribution])
+    end
+
+    def update_lease(lease, application_id, _primary_contact_id)
+      @client.update!('Lease__c',
+                      Id: lease[:id],
+                      Application__c: application_id,
+                      # Tenant__c: primary_contact_id,
+                      Unit__c: lease[:unit],
+                      Lease_Status__c: lease[:leaseStatus],
+                      Lease_Start_Date__c: lease[:leaseStartDate],
+                      Monthly_Parking_Rent__c: lease[:monthlyParkingRent],
+                      Total_Monthly_Rent_without_Parking__c: lease[:totalMonthlyRentWithoutParking],
+                      Monthly_Tenant_Contribution__c: lease[:monthlyTenantContribution])
     end
   end
 end

--- a/app/services/force/lease_service.rb
+++ b/app/services/force/lease_service.rb
@@ -1,0 +1,48 @@
+module Force
+  # Encapsulate all Salesforce Lease__c querying and updating functions.
+  class LeaseService < Force::Base
+    def lease(application_id)
+      builder.from(:Lease__c)
+             .select(:Id,
+                     :Unit__c,
+                     :Lease_Start_Date__c,
+                     :Lease_Status__c,
+                     :Monthly_Parking_Rent__c,
+                     :Total_Monthly_Rent_without_Parking__c,
+                     :Monthly_Tenant_Contribution__c)
+             .where_eq(:Application__c, application_id, :string)
+             .transform_results { |results| massage(results) }
+             .query
+             .records
+             .first
+    end
+
+    def submit_lease(lease, application_id, _primary_contact_id)
+      # Update
+      # FIXME: Fix Tenant__c permissions so we can submit these values.
+      if lease[:id]
+        response = @client.update!('Lease__c',
+                                   Id: lease[:id],
+                                   # Tenant__c: primary_contact_id,
+                                   Unit__c: lease[:unit],
+                                   Lease_Status__c: lease[:leaseStatus],
+                                   Lease_Start_Date__c: lease[:leaseStartDate],
+                                   Monthly_Parking_Rent__c: lease[:monthlyParkingRent],
+                                   Total_Monthly_Rent_without_Parking__c: lease[:totalMonthlyRentWithoutParking],
+                                   Monthly_Tenant_Contribution__c: lease[:monthlyTenantContribution])
+      else
+        # Create
+        response = @client.create!('Lease__c',
+                                   Application__c: application_id,
+                                   # Tenant__c: primary_contact_id,
+                                   Unit__c: lease[:unit],
+                                   Lease_Status__c: 'Draft',
+                                   Lease_Start_Date__c: lease[:leaseStartDate],
+                                   Monthly_Parking_Rent__c: lease[:monthlyParkingRent],
+                                   Total_Monthly_Rent_without_Parking__c: lease[:totalMonthlyRentWithoutParking],
+                                   Monthly_Tenant_Contribution__c: lease[:monthlyTenantContribution])
+      end
+      response
+    end
+  end
+end

--- a/config/salesforce/fields/applications.yml
+++ b/config/salesforce/fields/applications.yml
@@ -76,6 +76,7 @@ applications:
     Name:
       label: 'Application Number'
     Applicant__c:
+    Primary_Applicant__c:
     Alternate_Contact__c:
     Listing__c:
     Listing__r.Name:


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1405352/stories/158157958

Outstanding items

- [x] Move saving Tenant to separate story, or resolve salesforce blocker -*Moved*
- [x] Re-pull application data on supplemental application save to avoid creating multiple leases. As it is currently, we don't get the lease Id back on save, so every save without refreshing the page will lead to a new lease object being created. *Added a window href to reload the page, TBC whether that's a good solution*