### PR TITLE
Chore/ production lap tests #158582269

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ E2E_SALESFORCE_USERNAME=dahlia-leasing-agent@exygy.com.full
 E2E_SALESFORCE_PASSWORD=<ask the team for this password>
 ```
 
+To view the e2e tests as they're running, set `HEADLESS` to `false` in [this file](https://github.com/Exygy/sf-dahlia-lap/blob/master/spec/javascript/support/puppeteer/consts.js)
 **Run server**
 
 Run your Rails server locally in port 3000:

--- a/spec/javascript/e2e/ApplicationNewPage.e2e.js
+++ b/spec/javascript/e2e/ApplicationNewPage.e2e.js
@@ -2,7 +2,7 @@ import puppeteer from 'puppeteer'
 
 import utils from '../support/puppeteer/utils'
 import steps from '../support/puppeteer/steps'
-import { LEASE_UP_LISTING_ID, DEFAULT_E2E_TIME_OUT } from '../support/puppeteer/consts'
+import { LEASE_UP_LISTING_ID, DEFAULT_E2E_TIME_OUT, HEADLESS } from '../support/puppeteer/consts'
 
 describe('ApplicationNewPage', () => {
   test('should create a new application', async () => {
@@ -10,7 +10,7 @@ describe('ApplicationNewPage', () => {
     const LAST_NAME = 'Some last name'
     const DATE_OF_BIRTH = '03/03/1983'
 
-    let browser = await puppeteer.launch({ headless: true })
+    let browser = await puppeteer.launch({ headless: HEADLESS })
     let page = await browser.newPage()
 
     await steps.loginAsAgent(page)
@@ -38,7 +38,7 @@ describe('ApplicationNewPage', () => {
   }, DEFAULT_E2E_TIME_OUT)
 
   test('should fail if required fields are missing', async () => {
-    let browser = await puppeteer.launch({ headless: true })
+    let browser = await puppeteer.launch({ headless: HEADLESS })
     let page = await browser.newPage()
 
     await steps.loginAsAgent(page)

--- a/spec/javascript/e2e/LeaseUpPage.e2e.js
+++ b/spec/javascript/e2e/LeaseUpPage.e2e.js
@@ -1,11 +1,11 @@
 import puppeteer from 'puppeteer'
 
 import steps from '../support/puppeteer/steps'
-import { LEASE_UP_LISTING_ID, DEFAULT_E2E_TIME_OUT } from '../support/puppeteer/consts'
+import { LEASE_UP_LISTING_ID, DEFAULT_E2E_TIME_OUT, HEADLESS } from '../support/puppeteer/consts'
 
 describe('LeaseUpPage', () => {
   test('should change "Lease Up Status" for specific application preference using dropdown in row', async () => {
-    let browser = await puppeteer.launch({ headless: true })
+    let browser = await puppeteer.launch({ headless: HEADLESS })
     let page = await browser.newPage()
 
     await steps.loginAsAgent(page)

--- a/spec/javascript/e2e/Login.e2e.js
+++ b/spec/javascript/e2e/Login.e2e.js
@@ -1,9 +1,10 @@
 import puppeteer from 'puppeteer'
+import { HEADLESS } from '../support/puppeteer/consts'
 
 describe('Lead header', () => {
   test('lead header loads correctly', async () => {
     let browser = await puppeteer.launch({
-      headless: true // change this to false to launch a browser
+      headless: HEADLESS
     })
     let page = await browser.newPage()
 

--- a/spec/javascript/support/puppeteer/consts.js
+++ b/spec/javascript/support/puppeteer/consts.js
@@ -1,7 +1,7 @@
-// 855 Brannan
-export const LEASE_UP_LISTING_ID = 'a0W0P00000DZfSpUAL'
-
-// Yellow Acres
-// export const LEASE_UP_LISTING_ID = 'a0W0U000000MX4vUAG'
+// Default to Yellow Acres on Full
+export const LEASE_UP_LISTING_ID = process.env.E2E_LEASE_UP_LISTING_ID || 'a0W0U000000MX4vUAG'
 
 export const DEFAULT_E2E_TIME_OUT = 260000
+
+// Change to false to see tests running on browser locally
+export const HEADLESS = true


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/158582269

Solution:

Make listing ID configurable via env var:
- Set to Brannan on Semaphore Full
- Set to yellow acres on Semaphore Prod

It defaults to yellow acres on full, but currently that breaks things, so you can just set the env var E2E_LEASE_UP_LISTING_ID if you want it to be something else locally. 

Here's a passing build on the production semaphore job, running against the prod salesforce instance: https://semaphoreci.com/exygy/sf-dahlia-lap-prod/branches/chore-production-lap-tests-158582269/builds/3