### PR TITLE
Bugs/rental assistance delete error #162430991

### DIFF
--- a/app/javascript/components/supplemental_application/sections/RentalAssistance.js
+++ b/app/javascript/components/supplemental_application/sections/RentalAssistance.js
@@ -218,15 +218,19 @@ const AddRentalAssistanceForm = ({ values, onSave, loading, onClose, application
                 disabled={loading}>
                 Cancel
               </button>
-              { !isNew && (
-                <button
-                  className='button alert-fill tiny margin-bottom-none right'
-                  type='button'
-                  onClick={onDelete}
-                  disabled={loading}>
-                  Delete
-                </button>
-              )}
+              {
+                /* TODO: Re-enable the delete button when the Salesforce custom API
+                endpoint for deleting rental assistances is deployed to Prod. */
+                false && !isNew && (
+                  <button
+                    className='button alert-fill tiny margin-bottom-none right'
+                    type='button'
+                    onClick={onDelete}
+                    disabled={loading}>
+                    Delete
+                  </button>
+                )
+              }
             </div>
           </FormGrid.Row>
         </div>

--- a/spec/javascript/components/supplemental_application/sections/__snapshots__/RentalAssistance.test.js.snap
+++ b/spec/javascript/components/supplemental_application/sections/__snapshots__/RentalAssistance.test.js.snap
@@ -352,14 +352,6 @@ Array [
                         >
                           Cancel
                         </button>
-                        <button
-                          className="button alert-fill tiny margin-bottom-none right"
-                          disabled={undefined}
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          Delete
-                        </button>
                       </div>
                     </div>
                   </div>
@@ -1003,14 +995,6 @@ Array [
                         >
                           Cancel
                         </button>
-                        <button
-                          className="button alert-fill tiny margin-bottom-none right"
-                          disabled={undefined}
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          Delete
-                        </button>
                       </div>
                     </div>
                   </div>
@@ -1408,14 +1392,6 @@ Array [
                           type="button"
                         >
                           Cancel
-                        </button>
-                        <button
-                          className="button alert-fill tiny margin-bottom-none right"
-                          disabled={undefined}
-                          onClick={[Function]}
-                          type="button"
-                        >
-                          Delete
                         </button>
                       </div>
                     </div>

--- a/spec/javascript/e2e/SupplementalApplicationPage/rental_assistance.e2e.js
+++ b/spec/javascript/e2e/SupplementalApplicationPage/rental_assistance.e2e.js
@@ -111,33 +111,36 @@ describe('SupplementalApplicationPage Rental Assistance Information section', ()
   // This test requires a rental assistance to be already present in the rental
   // assistances table. If the prior test for creating a rental assistance has
   // succeeded, then there will be at least one rental assistance present.
-  test('should allow a rental assistance to be deleted', async () => {
-    let browser = await puppeteer.launch({ headless: HEADLESS })
-    let page = await browser.newPage()
 
-    await sharedSteps.loginAsAgent(page)
-    await sharedSteps.goto(page, `/applications/${LEASE_UP_LISTING_APPLICATION_ID}/supplementals`)
+  // TODO: Uncomment the below test when the Salesforce work for the custom API
+  // endpoint that allows rental assistance deletion is deployed to Prod.
+  // test('should allow a rental assistance to be deleted', async () => {
+  //   let browser = await puppeteer.launch({ headless: HEADLESS })
+  //   let page = await browser.newPage()
 
-    // Record how many rental assistances are in the table before we attempt our delete
-    const prevTableSize = await page.$$eval('.rental-assistances > tbody > .tr-expand', elems => elems.length)
+  //   await sharedSteps.loginAsAgent(page)
+  //   await sharedSteps.goto(page, `/applications/${LEASE_UP_LISTING_APPLICATION_ID}/supplementals`)
 
-    // Click the Edit button on the first rental assistance
-    const firstRentalAssistanceSelector = '.rental-assistances > tbody > .tr-expand:first-child'
-    await page.click(`${firstRentalAssistanceSelector} button.action-link`)
+  //   // Record how many rental assistances are in the table before we attempt our delete
+  //   const prevTableSize = await page.$$eval('.rental-assistances > tbody > .tr-expand', elems => elems.length)
 
-    // Wait for the edit rental assistance form to open
-    await page.waitForSelector('.rental-assistance-edit-form')
+  //   // Click the Edit button on the first rental assistance
+  //   const firstRentalAssistanceSelector = '.rental-assistances > tbody > .tr-expand:first-child'
+  //   await page.click(`${firstRentalAssistanceSelector} button.action-link`)
 
-    // Delete the rental assistance
-    await page.click('.rental-assistance-edit-form button.alert-fill')
+  //   // Wait for the edit rental assistance form to open
+  //   await page.waitForSelector('.rental-assistance-edit-form')
 
-    // Wait for the API rental assistance delete call to complete
-    await page.waitForResponse(request => request.url().includes('http://localhost:3000/api/v1/rental-assistances'))
+  //   // Delete the rental assistance
+  //   await page.click('.rental-assistance-edit-form button.alert-fill')
 
-    // Check that the rental assistances table has decreased in size by one
-    const newTableSize = await page.$$eval('.rental-assistances > tbody > .tr-expand', elems => elems.length)
-    expect(newTableSize).toEqual(prevTableSize - 1)
+  //   // Wait for the API rental assistance delete call to complete
+  //   await page.waitForResponse(request => request.url().includes('http://localhost:3000/api/v1/rental-assistances'))
 
-    await browser.close()
-  }, DEFAULT_E2E_TIME_OUT)
+  //   // Check that the rental assistances table has decreased in size by one
+  //   const newTableSize = await page.$$eval('.rental-assistances > tbody > .tr-expand', elems => elems.length)
+  //   expect(newTableSize).toEqual(prevTableSize - 1)
+
+  //   await browser.close()
+  // }, DEFAULT_E2E_TIME_OUT)
 })


### PR DESCRIPTION
The rental assistance delete functionality is only possible via a custom Salesforce API endpoint that allows rental assistance deletion. This Salesforce work is not yet deployed to Prod, so we are disabling the rental assistance delete function by hiding the button. When the Salesforce work is on Prod, we will re-enable rental assistance deletion. This PR also contains the disabling or removal of any tests or parts of tests that involved rental assistance delete functionality.