### PR TITLE
[Hotfix] Stop flagged app comment field from losing focus on typing #165830985

### DIFF
--- a/app/javascript/components/SpreadsheetIndexTable.js
+++ b/app/javascript/components/SpreadsheetIndexTable.js
@@ -66,6 +66,9 @@ class SpreadsheetIndexTable extends React.Component {
     return columns
   }
 
+  // Columns must be defined outside of ReactTable render (https://github.com/tannerlinsley/react-table/issues/1266)
+  columns = this.columnData()
+
   onCellChange = (cellInfo) => {
     return (e) => {
       var editData = [...this.state.editData]
@@ -154,7 +157,7 @@ class SpreadsheetIndexTable extends React.Component {
     // NOTE: sorting works oddly when expanded rows are open, so it is turned off
     return (
       <ReactTable
-        columns={this.columnData()}
+        columns={this.columns}
         data={this.state.persistedData}
         sortable={false}
         SubComponent={flaggedApplicationRow}

--- a/spec/javascript/e2e/FlaggedApplicationsShowPage.e2e.js
+++ b/spec/javascript/e2e/FlaggedApplicationsShowPage.e2e.js
@@ -1,0 +1,49 @@
+import puppeteer from 'puppeteer'
+
+import utils from '../support/puppeteer/utils'
+import sharedSteps from '../support/puppeteer/steps/sharedSteps'
+import {
+  FLAGGED_RECORD_SET_ID,
+  DEFAULT_E2E_TIME_OUT,
+  HEADLESS
+} from '../support/puppeteer/consts'
+
+describe('FlaggedApplicationsShowPage', () => {
+  test('should allow comments to be updated', async () => {
+    let browser = await puppeteer.launch({ headless: HEADLESS })
+    let page = await browser.newPage()
+
+    await sharedSteps.loginAsAgent(page)
+    await sharedSteps.goto(page, `/applications/flagged/${FLAGGED_RECORD_SET_ID}`)
+
+    const commentInputSelector = 'input[type="text"]'
+    const sampleComment = 'Test Commment'
+    const openRowSelector = '.rt-expander.-open'
+
+    // Open up a row
+    await page.click('.rt-expander')
+    let hasCommentInput = await utils.isPresent(page, commentInputSelector)
+    expect(hasCommentInput).toBe(true)
+
+    let hasOpenRow = await utils.isPresent(page, openRowSelector)
+    expect(hasOpenRow).toBe(true)
+
+    // Type
+    await sharedSteps.enterValue(page, commentInputSelector, sampleComment)
+
+    // Verify that it's been typed
+    let value = await sharedSteps.getValue(page, commentInputSelector)
+    expect(value).toEqual(sampleComment)
+
+    // Save the change
+    const saveButtonList = await page.$x("//button[contains(text(), 'Save Changes')]")
+    await saveButtonList[0].click()
+
+    // Expect the row to be closed
+    await page.waitFor(() => !document.querySelector('.rt-expander.-open'))
+    hasOpenRow = await utils.isPresent(page, openRowSelector)
+    expect(hasOpenRow).toBe(false)
+
+    await browser.close()
+  }, DEFAULT_E2E_TIME_OUT)
+})

--- a/spec/javascript/e2e/SupplementalApplicationPage/confirmed_household.e2e.js
+++ b/spec/javascript/e2e/SupplementalApplicationPage/confirmed_household.e2e.js
@@ -37,9 +37,9 @@ describe('SupplementalApplicationPage confirmed household income section', () =>
     await page.waitForNavigation()
 
     // Verify that the values are there (as numbers, not currency)
-    expect(await sharedSteps.getValue(page, hhAssetsSelector)).toEqual(String(hhAssetsValue.float))
-    expect(await sharedSteps.getValue(page, confirmedAnnualSelector)).toEqual(String(confirmedAnnualValue.float))
-    expect(await sharedSteps.getValue(page, finalHHAnnualSelector)).toEqual(String(finalHHAnnualValue.float))
+    expect(await sharedSteps.getInputValue(page, hhAssetsSelector)).toEqual(String(hhAssetsValue.float))
+    expect(await sharedSteps.getInputValue(page, confirmedAnnualSelector)).toEqual(String(confirmedAnnualValue.float))
+    expect(await sharedSteps.getInputValue(page, finalHHAnnualSelector)).toEqual(String(finalHHAnnualValue.float))
 
     await browser.close()
   }, DEFAULT_E2E_TIME_OUT)

--- a/spec/javascript/e2e/SupplementalApplicationPage/confirmed_household.e2e.js
+++ b/spec/javascript/e2e/SupplementalApplicationPage/confirmed_household.e2e.js
@@ -26,9 +26,9 @@ describe('SupplementalApplicationPage confirmed household income section', () =>
     const finalHHAnnualValue = supplementalApplicationSteps.generateRandomCurrency()
 
     // Enter them
-    await supplementalApplicationSteps.enterValue(page, hhAssetsSelector, hhAssetsValue.currency)
-    await supplementalApplicationSteps.enterValue(page, confirmedAnnualSelector, confirmedAnnualValue.currency)
-    await supplementalApplicationSteps.enterValue(page, finalHHAnnualSelector, finalHHAnnualValue.currency)
+    await sharedSteps.enterValue(page, hhAssetsSelector, hhAssetsValue.currency)
+    await sharedSteps.enterValue(page, confirmedAnnualSelector, confirmedAnnualValue.currency)
+    await sharedSteps.enterValue(page, finalHHAnnualSelector, finalHHAnnualValue.currency)
 
     // Click save
     await supplementalApplicationSteps.savePage(page)
@@ -37,9 +37,9 @@ describe('SupplementalApplicationPage confirmed household income section', () =>
     await page.waitForNavigation()
 
     // Verify that the values are there (as numbers, not currency)
-    expect(await supplementalApplicationSteps.getValue(page, hhAssetsSelector)).toEqual(String(hhAssetsValue.float))
-    expect(await supplementalApplicationSteps.getValue(page, confirmedAnnualSelector)).toEqual(String(confirmedAnnualValue.float))
-    expect(await supplementalApplicationSteps.getValue(page, finalHHAnnualSelector)).toEqual(String(finalHHAnnualValue.float))
+    expect(await sharedSteps.getValue(page, hhAssetsSelector)).toEqual(String(hhAssetsValue.float))
+    expect(await sharedSteps.getValue(page, confirmedAnnualSelector)).toEqual(String(confirmedAnnualValue.float))
+    expect(await sharedSteps.getValue(page, finalHHAnnualSelector)).toEqual(String(finalHHAnnualValue.float))
 
     await browser.close()
   }, DEFAULT_E2E_TIME_OUT)

--- a/spec/javascript/e2e/SupplementalApplicationPage/lease_information.e2e.js
+++ b/spec/javascript/e2e/SupplementalApplicationPage/lease_information.e2e.js
@@ -26,9 +26,9 @@ describe('SupplementalApplicationPage lease section', () => {
     const tenantContributionValue = supplementalApplicationSteps.generateRandomCurrency()
 
     // Enter them
-    await supplementalApplicationSteps.enterValue(page, rentSelector, rentValue.currency)
-    await supplementalApplicationSteps.enterValue(page, parkingRentSelector, parkingRentValue.currency)
-    await supplementalApplicationSteps.enterValue(page, tenantContributionSelector, tenantContributionValue.currency)
+    await sharedSteps.enterValue(page, rentSelector, rentValue.currency)
+    await sharedSteps.enterValue(page, parkingRentSelector, parkingRentValue.currency)
+    await sharedSteps.enterValue(page, tenantContributionSelector, tenantContributionValue.currency)
 
     // Click save
     await supplementalApplicationSteps.savePage(page)
@@ -37,9 +37,9 @@ describe('SupplementalApplicationPage lease section', () => {
     await page.waitForNavigation()
 
     // Verify that the values are there (they will be returned from salesforce as numbers, not currency)
-    expect(await supplementalApplicationSteps.getValue(page, rentSelector)).toEqual(String(rentValue.float))
-    expect(await supplementalApplicationSteps.getValue(page, parkingRentSelector)).toEqual(String(parkingRentValue.float))
-    expect(await supplementalApplicationSteps.getValue(page, tenantContributionSelector)).toEqual(String(tenantContributionValue.float))
+    expect(await sharedSteps.getValue(page, rentSelector)).toEqual(String(rentValue.float))
+    expect(await sharedSteps.getValue(page, parkingRentSelector)).toEqual(String(parkingRentValue.float))
+    expect(await sharedSteps.getValue(page, tenantContributionSelector)).toEqual(String(tenantContributionValue.float))
 
     await browser.close()
   }, DEFAULT_E2E_TIME_OUT)

--- a/spec/javascript/e2e/SupplementalApplicationPage/lease_information.e2e.js
+++ b/spec/javascript/e2e/SupplementalApplicationPage/lease_information.e2e.js
@@ -37,9 +37,9 @@ describe('SupplementalApplicationPage lease section', () => {
     await page.waitForNavigation()
 
     // Verify that the values are there (they will be returned from salesforce as numbers, not currency)
-    expect(await sharedSteps.getValue(page, rentSelector)).toEqual(String(rentValue.float))
-    expect(await sharedSteps.getValue(page, parkingRentSelector)).toEqual(String(parkingRentValue.float))
-    expect(await sharedSteps.getValue(page, tenantContributionSelector)).toEqual(String(tenantContributionValue.float))
+    expect(await sharedSteps.getInputValue(page, rentSelector)).toEqual(String(rentValue.float))
+    expect(await sharedSteps.getInputValue(page, parkingRentSelector)).toEqual(String(parkingRentValue.float))
+    expect(await sharedSteps.getInputValue(page, tenantContributionSelector)).toEqual(String(tenantContributionValue.float))
 
     await browser.close()
   }, DEFAULT_E2E_TIME_OUT)

--- a/spec/javascript/e2e/SupplementalApplicationPage/preferences.e2e.js
+++ b/spec/javascript/e2e/SupplementalApplicationPage/preferences.e2e.js
@@ -7,14 +7,6 @@ import {
   HEADLESS
 } from '../../support/puppeteer/consts'
 
-const getUnselectedOptSelector = (fieldSelector) => {
-  return `${fieldSelector} option:not(:checked):not(:disabled)`
-}
-
-const getSelectedOptSelector = (fieldSelector) => {
-  return `${fieldSelector} option:checked`
-}
-
 describe('SupplementalApplicationPage Confirmed Preferences section', () => {
   test('should allow updates to live/work preference', async () => {
     let browser = await puppeteer.launch({ headless: HEADLESS })
@@ -36,21 +28,21 @@ describe('SupplementalApplicationPage Confirmed Preferences section', () => {
 
     // Update the individual preference (select Live vs Work in SF)
     const individualPreferenceSelector = `${liveWorkExpandedPanelSelector} .individual-preference-select`
-    const unselectedPreferenceSelector = getUnselectedOptSelector(individualPreferenceSelector)
+    const unselectedPreferenceSelector = sharedSteps.notSelectedOptionSelector(individualPreferenceSelector)
     const prefToSetName = await page.$eval(unselectedPreferenceSelector, e => e.textContent)
     const prefToSetValue = await page.$eval(unselectedPreferenceSelector, e => e.value)
     await page.select(individualPreferenceSelector, prefToSetValue)
 
     // Update the type of proof
     const typeOfProofSelector = `${liveWorkExpandedPanelSelector} .type-of-proof-select`
-    const unselectedTypeOfProofSelector = getUnselectedOptSelector(typeOfProofSelector)
+    const unselectedTypeOfProofSelector = sharedSteps.notSelectedOptionSelector(typeOfProofSelector)
     const typeOfProofToSetName = await page.$eval(unselectedTypeOfProofSelector, e => e.textContent)
     const typeOfProofToSetValue = await page.$eval(unselectedTypeOfProofSelector, e => e.value)
     await page.select(typeOfProofSelector, typeOfProofToSetValue)
 
     // Update the preference status
     const prefStatusSelector = `${liveWorkExpandedPanelSelector} .preference-status-select`
-    const unselectedPrefStatusSelector = getUnselectedOptSelector(prefStatusSelector)
+    const unselectedPrefStatusSelector = sharedSteps.notSelectedOptionSelector(prefStatusSelector)
     const prefStatusToSetName = await page.$eval(unselectedPrefStatusSelector, e => e.textContent)
     const prefStatusToSetValue = await page.$eval(unselectedPrefStatusSelector, e => e.value)
     await page.select(prefStatusSelector, prefStatusToSetValue)
@@ -81,13 +73,13 @@ describe('SupplementalApplicationPage Confirmed Preferences section', () => {
 
     // Check that the value entered for individual preference, type of proof, and status were successfully saved
     // and now appears in the preference panel
-    const currentIndividualPref = await page.$eval(getSelectedOptSelector(individualPreferenceSelector), e => e.textContent)
+    const currentIndividualPref = await page.$eval(sharedSteps.selectedOptionSelector(individualPreferenceSelector), e => e.textContent)
     expect(currentIndividualPref).toBe(prefToSetName)
 
-    const currentTypeOfProof = await page.$eval(getSelectedOptSelector(typeOfProofSelector), e => e.textContent)
+    const currentTypeOfProof = await page.$eval(sharedSteps.selectedOptionSelector(typeOfProofSelector), e => e.textContent)
     expect(currentTypeOfProof).toBe(typeOfProofToSetName)
 
-    const currentStatus = await page.$eval(getSelectedOptSelector(prefStatusSelector), e => e.textContent)
+    const currentStatus = await page.$eval(sharedSteps.selectedOptionSelector(prefStatusSelector), e => e.textContent)
     expect(currentStatus).toBe(prefStatusToSetName)
 
     await browser.close()
@@ -113,7 +105,7 @@ describe('SupplementalApplicationPage Confirmed Preferences section', () => {
 
     // Update the preference status
     const prefStatusSelector = `${assistedHousingExpandedPanelSelector} .preference-status-select`
-    const unselectedPrefStatusSelector = getUnselectedOptSelector(prefStatusSelector)
+    const unselectedPrefStatusSelector = sharedSteps.notSelectedOptionSelector(prefStatusSelector)
     const prefStatusToSetName = await page.$eval(unselectedPrefStatusSelector, e => e.textContent)
     const prefStatusToSetValue = await page.$eval(unselectedPrefStatusSelector, e => e.value)
     await page.select(prefStatusSelector, prefStatusToSetValue)
@@ -141,7 +133,7 @@ describe('SupplementalApplicationPage Confirmed Preferences section', () => {
 
     // Check that the value entered for status was successfully saved
     // and now appears in the preference panel
-    const currentStatus = await page.$eval(getSelectedOptSelector(prefStatusSelector), e => e.textContent)
+    const currentStatus = await page.$eval(sharedSteps.selectedOptionSelector(prefStatusSelector), e => e.textContent)
     expect(currentStatus).toBe(prefStatusToSetName)
 
     await browser.close()

--- a/spec/javascript/support/puppeteer/consts.js
+++ b/spec/javascript/support/puppeteer/consts.js
@@ -9,8 +9,11 @@ export const LEASE_UP_LISTING_APPLICATION_ID = process.env.E2E_LEASE_UP_LISTING_
 
 export const DEFAULT_E2E_TIME_OUT = 60000 // 1 minute
 
-// Change to false to see tests running on browser locally
-export const HEADLESS = true
-
 // Default to Sale Test Listing Homeownership Acres on Full
 export const SALE_LISTING_ID = process.env.E2E_SALE_LISTING_ID || 'a0W0P00000GlKfBUAV'
+
+// Default to sample flagged record set on full
+export const FLAGGED_RECORD_SET_ID = process.env.E2E_FLAGGED_RECORD_SET_ID || 'a0r0t000001y7rd'
+
+// Change to false to see tests running on browser locally
+export const HEADLESS = true

--- a/spec/javascript/support/puppeteer/steps/sharedSteps.js
+++ b/spec/javascript/support/puppeteer/steps/sharedSteps.js
@@ -36,11 +36,30 @@ const enterValue = async (page, selector, value) => {
   await page.type(selector, value)
 }
 
-const getValue = async (page, selector) => {
+const getInputValue = async (page, selector) => {
   await page.waitForSelector(selector)
   const input = await page.$(selector)
   const valueHandle = await input.getProperty('value')
   return valueHandle.jsonValue()
+}
+
+const getText = async (page, selector) => {
+  return page.$eval(selector, e => e.textContent)
+}
+
+const generateRandomString = (length) => {
+  // Due to 0s potentially present in the random number,
+  // there is a chance that this function could return a string shorter than the desired length.
+  // Source: https://stackoverflow.com/a/38622545
+  return Math.random().toString(36).substr(2, length)
+}
+
+const notSelectedOptionSelector = (fieldSelector) => {
+  return `${fieldSelector} option:not(:checked):not(:disabled)`
+}
+
+const selectedOptionSelector = (fieldSelector) => {
+  return `${fieldSelector} option:checked`
 }
 
 export default {
@@ -48,5 +67,9 @@ export default {
   goto,
   waitForApp,
   enterValue,
-  getValue
+  getInputValue,
+  getText,
+  generateRandomString,
+  notSelectedOptionSelector,
+  selectedOptionSelector
 }

--- a/spec/javascript/support/puppeteer/steps/sharedSteps.js
+++ b/spec/javascript/support/puppeteer/steps/sharedSteps.js
@@ -27,8 +27,26 @@ const waitForApp = async (page) => {
   await page.waitForSelector('#root')
 }
 
+const enterValue = async (page, selector, value) => {
+  // Wait for the field to appear
+  await page.waitForSelector(selector)
+  // Clear the value that's there
+  await page.$eval(selector, (el) => { el.value = '' })
+  // Enter the value
+  await page.type(selector, value)
+}
+
+const getValue = async (page, selector) => {
+  await page.waitForSelector(selector)
+  const input = await page.$(selector)
+  const valueHandle = await input.getProperty('value')
+  return valueHandle.jsonValue()
+}
+
 export default {
   loginAsAgent,
   goto,
-  waitForApp
+  waitForApp,
+  enterValue,
+  getValue
 }

--- a/spec/javascript/support/puppeteer/steps/supplementalApplicationSteps.js
+++ b/spec/javascript/support/puppeteer/steps/supplementalApplicationSteps.js
@@ -36,22 +36,6 @@ const generateRandomCurrency = () => {
   return {'currency': `$${val}`, 'float': val}
 }
 
-const enterValue = async (page, selector, value) => {
-  // Wait for the field to appear
-  await page.waitForSelector(selector)
-  // Clear the value that's there
-  await page.$eval(selector, (el) => { el.value = '' })
-  // Enter the value
-  await page.type(selector, value)
-}
-
-const getValue = async (page, selector) => {
-  await page.waitForSelector(selector)
-  const input = await page.$(selector)
-  const valueHandle = await input.getProperty('value')
-  return valueHandle.jsonValue()
-}
-
 const savePage = async (page) => {
   const selector = '#save-supplemental-application'
   // To allow waitForNavigation to work post-save, we need to scroll
@@ -65,9 +49,7 @@ const savePage = async (page) => {
 }
 
 export default {
-  enterValue,
   generateRandomCurrency,
-  getValue,
   savePage,
   testStatusModalUpdate
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7245,8 +7245,8 @@ react-scrollable-anchor@^0.6.1:
     prop-types "^15.5.10"
 
 react-table@^6.9.2:
-  version "6.9.2"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-6.9.2.tgz#6a59adfeb8d5deced288241ed1c7847035b5ec5f"
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/react-table/-/react-table-6.10.0.tgz#20444b19d8ca3c1a08e7544e5c3a93e4ba56690e"
   dependencies:
     classnames "^2.2.5"
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/165830985

More details are on ticket, but TL;DR is that a react-table update changed the way tables were re-rendered and introduced issues if you pass columns as a function or build a component inside your ReactTable render rather than passing columns as a fully created object. 