### PR TITLE
Add validation to check for valid naturalKey selection #165942084

### DIFF
--- a/app/javascript/components/applications/application_form/PaperApplicationForm.js
+++ b/app/javascript/components/applications/application_form/PaperApplicationForm.js
@@ -14,7 +14,8 @@ import AlertBox from '~/components/molecules/AlertBox'
 import validate from '~/utils/form/validations'
 import { Form } from 'react-final-form'
 import arrayMutators from 'final-form-arrays'
-import { isEmpty } from 'lodash'
+import { includes, isEmpty } from 'lodash'
+import { naturalKeyFromMember } from './preferences/utils.js'
 
 class PaperApplicationForm extends React.Component {
   constructor (props) {
@@ -52,6 +53,22 @@ class PaperApplicationForm extends React.Component {
       errors.alternate_contact.first_name = validate.isPresent('Please enter a First Name')(values.alternate_contact.first_name)
       errors.alternate_contact.last_name = validate.isPresent('Please enter a Last Name')(values.alternate_contact.last_name)
       errors.alternate_contact.email = validate.isValidEmail('Please enter a valid Email')(values.alternate_contact.email)
+    }
+
+    // Secondary preference application member validation: Check if selected app member value is still a valid natural key.
+    if (values.preferences) {
+      // Combine household members with primary applicant to get list of all the natural keys
+      const allMembers = [values.applicant].concat(values.household_members ? values.household_members : [])
+      const naturalKeys = allMembers.map((member) => naturalKeyFromMember(member))
+      errors.preferences = []
+      values.preferences.map(
+        (pref, i) => {
+          errors.preferences = errors.preferences.concat({})
+          if (pref.naturalKey && !includes(naturalKeys, pref.naturalKey)) {
+            errors.preferences[i].naturalKey = 'This field is required'
+          }
+        }
+      )
     }
     return errors
   }

--- a/app/javascript/components/applications/application_form/PaperApplicationForm.js
+++ b/app/javascript/components/applications/application_form/PaperApplicationForm.js
@@ -14,8 +14,8 @@ import AlertBox from '~/components/molecules/AlertBox'
 import validate from '~/utils/form/validations'
 import { Form } from 'react-final-form'
 import arrayMutators from 'final-form-arrays'
-import { includes, isEmpty } from 'lodash'
-import { naturalKeyFromMember } from './preferences/utils.js'
+import { includes, isEmpty, map } from 'lodash'
+import { getFullHousehold, naturalKeyFromMember } from './preferences/utils.js'
 
 class PaperApplicationForm extends React.Component {
   constructor (props) {
@@ -57,9 +57,7 @@ class PaperApplicationForm extends React.Component {
 
     // Secondary preference application member validation: Check if selected app member value is still a valid natural key.
     if (values.preferences) {
-      // Combine household members with primary applicant to get list of all the natural keys
-      const allMembers = [values.applicant].concat(values.household_members ? values.household_members : [])
-      const naturalKeys = allMembers.map((member) => naturalKeyFromMember(member))
+      const naturalKeys = map(getFullHousehold(values), (member) => naturalKeyFromMember(member))
       errors.preferences = []
       values.preferences.map(
         (pref, i) => {

--- a/spec/javascript/components/applications/application_form/PaperApplicationForm.test.js
+++ b/spec/javascript/components/applications/application_form/PaperApplicationForm.test.js
@@ -9,7 +9,8 @@ import application from '../../../fixtures/domain_application'
 import lendingInstitutions from '../../../fixtures/lending_institutions'
 
 const mockSubmitApplication = jest.fn()
-const applicationWithInvalidAnnualIncome = clone(application)
+
+let testApplication = null
 
 jest.mock('apiService', () => {
   return {
@@ -22,16 +23,16 @@ jest.mock('apiService', () => {
 
 describe('PaperApplicationForm', () => {
   beforeEach(() => {
-    applicationWithInvalidAnnualIncome['annual_income'] = 'foo'
-    applicationWithInvalidAnnualIncome['application_language'] = null
+    testApplication = clone(application)
   })
 
   describe('should validate fields correctly: ', () => {
     test('Annual Income', async () => {
+      testApplication['annual_income'] = 'foo'
       const wrapper = mount(
         <PaperApplicationForm
           listing={listing}
-          application={applicationWithInvalidAnnualIncome}
+          application={testApplication}
         />
       )
 
@@ -49,10 +50,11 @@ describe('PaperApplicationForm', () => {
     })
 
     test('Language', async () => {
+      testApplication['application_language'] = null
       const wrapper = mount(
         <PaperApplicationForm
           listing={listing}
-          application={applicationWithInvalidAnnualIncome}
+          application={testApplication}
         />
       )
       wrapper.find('form').first().simulate('submit')
@@ -72,7 +74,7 @@ describe('PaperApplicationForm', () => {
         const wrapper = mount(
           <PaperApplicationForm
             listing={listing}
-            application={applicationWithInvalidAnnualIncome}
+            application={testApplication}
           />
         )
         expect(wrapper.text()).not.toContain('Eligibility Information')
@@ -89,7 +91,7 @@ describe('PaperApplicationForm', () => {
         const wrapper = mount(
           <PaperApplicationForm
             listing={listing}
-            application={applicationWithInvalidAnnualIncome}
+            application={testApplication}
           />
         )
         expect(wrapper.text()).toContain('Eligibility Information')
@@ -100,7 +102,7 @@ describe('PaperApplicationForm', () => {
           <PaperApplicationForm
             listing={listing}
             lendingInstitutions={lendingInstitutions}
-            application={applicationWithInvalidAnnualIncome}
+            application={testApplication}
           />
         )
         wrapper.find('#lending_institution select').simulate('change', { target: { value: 'First Republic Bank' } })
@@ -114,16 +116,13 @@ describe('PaperApplicationForm', () => {
       })
 
       describe('lending institution and lender dropdowns should be filled out', () => {
-        beforeEach(() => {
-          applicationWithInvalidAnnualIncome.lending_agent = '003U000001Wnp5gIAB'
-        })
-
         test('lender select should be filled out', async () => {
+          testApplication.lending_agent = '003U000001Wnp5gIAB'
           const wrapper = mount(
             <PaperApplicationForm
               listing={listing}
               lendingInstitutions={lendingInstitutions}
-              application={applicationWithInvalidAnnualIncome}
+              application={testApplication}
             />
           )
           await wait(100)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/165942084

Strategy ended up being:
1. Keep field-level validation for normal checking if app member is present with validate.isRequired.
2. If there is a value for naturalKey on the preference, then check and make sure it's valid on the form level.
