### PR TITLE
Add clearer error handling to confirmed preference save issue #170144565

### DIFF
--- a/app/controllers/api/v1/applications_controller.rb
+++ b/app/controllers/api/v1/applications_controller.rb
@@ -16,6 +16,7 @@ module Api
         response = rest_application_service.update(application_params.merge(id: params[:id]))
         if response
           render json: true
+        end
       end
 
       private

--- a/app/controllers/api/v1/applications_controller.rb
+++ b/app/controllers/api/v1/applications_controller.rb
@@ -16,9 +16,6 @@ module Api
         response = rest_application_service.update(application_params.merge(id: params[:id]))
         if response
           render json: true
-        else
-          render status: 422, json: false
-        end
       end
 
       private

--- a/app/controllers/api/v1/preferences_controller.rb
+++ b/app/controllers/api/v1/preferences_controller.rb
@@ -10,8 +10,6 @@ module Api
         response = rest_preference_service.update(preference_params.merge(id: params[:id]))
         if response
           render json: true
-        else
-          render status: 422, json: false
         end
       end
 

--- a/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
+++ b/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
@@ -56,10 +56,15 @@ class SupplementalApplicationPage extends React.Component {
   }
 
   handleSavePreference = async (preferenceIndex, formApplicationValues) => {
-    const responses = await Promise.all([
-      updateTotalHouseholdRent(formApplicationValues.id, formApplicationValues.total_monthly_rent),
-      updatePreference(formApplicationValues.preferences[preferenceIndex])
-    ])
+    const preference = formApplicationValues.preferences[preferenceIndex]
+    let updates = [ updatePreference(preference) ]
+    // If updating a rent burdened preference, we need to independently
+    // update the rent on the application.
+    if (preference.individual_preference === 'Rent Burdened') {
+      updates.push(updateTotalHouseholdRent(formApplicationValues.id, formApplicationValues.total_monthly_rent))
+    }
+
+    const responses = await Promise.all(updates)
     const failed = some(responses, response => response === false)
 
     if (!failed) {

--- a/app/javascript/components/supplemental_application/sections/preferences/Panel.js
+++ b/app/javascript/components/supplemental_application/sections/preferences/Panel.js
@@ -10,10 +10,12 @@ import AntiDisplacementHousingPanel from './AntiDisplacementHousingPanel'
 import AssistedHousingPanel from './AssistedHousingPanel'
 import Custom from './Custom'
 
-const isPreference = (record, preferenceName) => (pref) => {
+const isPreference = (recordType, preferenceName) => (pref) => {
   const recordtypeDevelopername = pref.recordtype_developername
   const individualPreference = pref.individual_preference
-  return recordtypeDevelopername === record &&
+
+  // If preferenceName is provided, check that the individual preference matches it.
+  return recordtypeDevelopername === recordType &&
     (
       !preferenceName ||
       individualPreference === preferenceName

--- a/app/javascript/components/supplemental_application/sections/preferences/RentBurdenedPanel.js
+++ b/app/javascript/components/supplemental_application/sections/preferences/RentBurdenedPanel.js
@@ -17,6 +17,7 @@ export const RentBurdenedPanel = ({ preferenceIndex }) => (
       </div>
     </FormItem>
     <FormItem>
+      {/* Total monthly rent is stored in the application, not the preference. */}
       <CurrencyField
         fieldName='total_monthly_rent'
         type='number'

--- a/app/services/force/rest/application_service.rb
+++ b/app/services/force/rest/application_service.rb
@@ -6,7 +6,7 @@ module Force
     class ApplicationService < Force::Base
       def update(domain_attrs)
         application = Force::Application.from_domain(domain_attrs)
-        @client.update('Application__c', application.to_salesforce)
+        @client.update!('Application__c', application.to_salesforce)
       end
     end
   end

--- a/app/services/force/rest/preference_service.rb
+++ b/app/services/force/rest/preference_service.rb
@@ -6,7 +6,7 @@ module Force
     class PreferenceService < Force::Base
       def update(domain_attrs)
         preference = Force::Preference.from_domain(domain_attrs)
-        @client.update('Application_Preference__c', preference.to_salesforce)
+        @client.update!('Application_Preference__c', preference.to_salesforce)
       end
     end
   end

--- a/spec/controllers/api/v1/applications_controller_spec.rb
+++ b/spec/controllers/api/v1/applications_controller_spec.rb
@@ -11,10 +11,37 @@ RSpec.describe Api::V1::ApplicationsController, type: :controller do
       VCR.use_cassette('api/v1/applications_controller/index') do
         get :index, params: { listing_id: valid_listing_id }
       end
-
       expect(response).to have_http_status(:success)
       json = JSON.parse(response.body)
       expect(json['records'].size).to eq(28)
+    end
+  end
+
+  describe '#update' do
+    it 'should render true if update is successful' do
+      VCR.use_cassette('api/v1/applications_controller/update/success') do
+        params = {
+          id: non_lease_up_application_id,
+          application: { id: non_lease_up_application_id, total_monthly_rent: '600'}
+        }
+        put :update, params: params
+      end
+      expect(response).to have_http_status(:success)
+      json = JSON.parse(response.body)
+      expect(json).to eq(true)
+    end
+
+    it 'should return with an error code if update is not successful' do
+      VCR.use_cassette('api/v1/applications_controller/update/failure') do
+        params = {
+          id: 'invalid_id',
+          application: { id: 'invalid_id', total_monthly_rent: '600'}
+        }
+        put :update, params: params
+      end
+      expect(response).to have_http_status(:service_unavailable)
+      json = JSON.parse(response.body)
+      expect(json['message']).to include('NOT_FOUND')
     end
   end
 end

--- a/spec/controllers/api/v1/preferences_controller_spec.rb
+++ b/spec/controllers/api/v1/preferences_controller_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Api::V1::PreferencesController, type: :controller do
+  render_views
+  login_admin
+
+  describe '#update' do
+    it 'should render true if update is successful' do
+      VCR.use_cassette('api/v1/preferences_controller/update/success') do
+        params = {
+          id: lease_up_preference_id,
+          preference: {
+            id: lease_up_preference_id,
+            individual_preference: 'Work in SF',
+            post_lottery_validation: 'Unconfirmed'
+          }
+        }
+        put :update, params: params
+      end
+      expect(response).to have_http_status(:success)
+      json = JSON.parse(response.body)
+      expect(json).to eq(true)
+    end
+
+    it 'should return with an error code if update is not successful' do
+      VCR.use_cassette('api/v1/preferences_controller/update/failure') do
+        params = {
+          id: 'invalid_id',
+          preference: {
+            id: 'invalid_id',
+            individual_preference: 'Work in SF',
+            post_lottery_validation: 'Unconfirmed'
+          }
+        }
+        put :update, params: params
+      end
+      expect(response).to have_http_status(:service_unavailable)
+      json = JSON.parse(response.body)
+      expect(json['message']).to include('NOT_FOUND')
+    end
+  end
+end

--- a/spec/javascript/components/supplemental_application/SupplementalApplicationPage.test.js
+++ b/spec/javascript/components/supplemental_application/SupplementalApplicationPage.test.js
@@ -86,7 +86,7 @@ describe('SupplementalApplicationPage', () => {
           units={units} />
       )
     })
-    await wrapper.find('form').first().simulate('submit')
+    await act(async () => { wrapper.find('form').first().simulate('submit') })
 
     expect(mockSubmitApplication.mock.calls.length).toBe(1)
     expect(mockSubmitApplication).toHaveBeenCalledWith(payload)
@@ -128,7 +128,7 @@ describe('SupplementalApplicationPage', () => {
     wrapper.find('#demographics-seniors select option[value=3]').simulate('change')
     wrapper.find('#demographics-minors select option[value=4]').simulate('change')
     wrapper.find('#demographics-marital-status select option[value="Domestic Partner"]').simulate('change')
-    wrapper.find('form').first().simulate('submit')
+    await act(async () => { wrapper.find('form').first().simulate('submit') })
 
     await wait(100)
 
@@ -136,22 +136,20 @@ describe('SupplementalApplicationPage', () => {
     expect(mockSubmitApplication.mock.calls[0][0]).toEqual(payload)
   })
 
-  test('it saves an application preference panel', async () => {
+  test('it saves a live/work application preference panel', async () => {
     const withValidPreferences = cloneDeep(supplementalApplication)
-    const payload = cloneDeep(mockShortFormSubmitPayload)
-
-    merge(payload.shortFormPreferences[0], {
-      appMemberID: 'xxx',
-      naturalKey: 'Bla,Ble,',
-      individualPreference: 'Live in SF'
-    })
-
     merge(withValidPreferences.preferences[0], {
       Preference_Name: 'Live or Work in San Francisco Preference',
       Individual_preference: 'Live in SF',
       Receives_Preference: true,
-      Application_Member: { Id: 'xxx', First_Name: 'Bla', Last_Name: 'Ble', DOB: '03/03/83' }
+      'RecordType.DeveloperName': 'L_W',
+      LW_Type_of_Proof: 'Water bill',
+      Application_Member: { Id: 'xxx', First_Name: 'Bla', Last_Name: 'Ble', DOB: '03/03/83' },
+      Id: 'preference_id',
+      Post_Lottery_Validation: 'Unconfirmed',
+      Name: 'AP-1234'
     })
+
     let wrapper
     await act(async () => {
       wrapper = mount(
@@ -162,13 +160,70 @@ describe('SupplementalApplicationPage', () => {
       )
     })
 
-    wrapper.find('.preferences-table .action-link').first().simulate('click')
-    wrapper.find('.preferences-table .save-panel-btn').simulate('click')
+    // Click edit to open up the panel
+    await wrapper.find('.preferences-table .action-link').first().simulate('click')
+    // Save the preference panel without making updates
+    await act(async () => { wrapper.find('.preferences-table .save-panel-btn').simulate('click') })
 
-    await wait(100)
+    const expectedPreferencePayload = {
+      id: 'preference_id',
+      application_member_id: 'xxx',
+      individual_preference: 'Live in SF',
+      type_of_proof: null,
+      lw_type_of_proof: 'Water bill',
+      post_lottery_validation: 'Unconfirmed'
+    }
 
+    expect(mockUpdateApplication.mock.calls.length).toBe(0)
+    expect(mockUpdatePreference.mock.calls.length).toBe(1)
+    // Additional fields are sent to the API, but these are the fields that we care about.
+    expect(mockUpdatePreference).toHaveBeenCalledWith(expect.objectContaining(expectedPreferencePayload))
+  })
+
+  test('it updates total monthly rent when saving a rent burdened preference panel', async () => {
+    const withValidPreferences = cloneDeep(supplementalApplication)
+
+    merge(withValidPreferences.preferences[0], {
+      Preference_Name: 'Rent Burdened Assisted Housing',
+      Individual_preference: 'Rent Burdened',
+      Receives_Preference: true,
+      Type_of_proof: 'Lease and rent proof',
+      Application_Member: { Id: 'xxx', First_Name: 'Bla', Last_Name: 'Ble', DOB: '03/03/83' },
+      Id: 'preference_id',
+      Post_Lottery_Validation: 'Unconfirmed',
+      Name: 'AP-1234',
+      'RecordType.DeveloperName': 'RB_AHP'
+    })
+
+    withValidPreferences.Id = 'application_id'
+    withValidPreferences.Total_Monthly_Rent = '50'
+    let wrapper
+    await act(async () => {
+      wrapper = mount(
+        <SupplementalApplicationPage
+          application={withValidPreferences}
+          statusHistory={statusHistory}
+        />
+      )
+    })
+
+    // Click edit to open up the panel
+    await wrapper.find('.preferences-table .action-link').first().simulate('click')
+    // Save the preference panel without making updates
+    await act(async () => { wrapper.find('.preferences-table .save-panel-btn').simulate('click') })
+
+    const expectedPreferencePayload = {
+      id: 'preference_id',
+      application_member_id: 'xxx',
+      individual_preference: 'Rent Burdened',
+      type_of_proof: 'Lease and rent proof',
+      lw_type_of_proof: null,
+      post_lottery_validation: 'Unconfirmed'
+    }
     expect(mockUpdateApplication.mock.calls.length).toBe(1)
     expect(mockUpdatePreference.mock.calls.length).toBe(1)
+    expect(mockUpdatePreference).toHaveBeenCalledWith(expect.objectContaining(expectedPreferencePayload))
+    expect(mockUpdateApplication).toHaveBeenCalledWith({'id': 'application_id', 'total_monthly_rent': '$50.00'})
   })
 
   describe('Lease Section', () => {
@@ -216,7 +271,7 @@ describe('SupplementalApplicationPage', () => {
       wrapper.find('[name="lease.monthly_tenant_contribution"] input').simulate('change', { target: { value: '$3' } })
 
       // Assert that they're sent to the API
-      await wrapper.find('form').first().simulate('submit')
+      await act(async () => { await wrapper.find('form').first().simulate('submit') })
 
       const expectedLease = {
         'id': undefined,
@@ -239,7 +294,7 @@ describe('SupplementalApplicationPage', () => {
       wrapper.find('[name="lease.unit"] select option[value=""]').simulate('change')
 
       // Hit save
-      await wrapper.find('form').first().simulate('submit')
+      await act(async () => { wrapper.find('form').first().simulate('submit') })
 
       // Verify that the API was called with null unit value
       expect(mockCreateOrUpdateLease.mock.calls.length).toBe(1)

--- a/spec/support/force_helpers.rb
+++ b/spec/support/force_helpers.rb
@@ -9,6 +9,7 @@ module ForceHelpers
   NOT_YET_RUN_LISTING_ID = 'a0W0P00000F8YG4UAN'
 
   LEASE_UP_APPLICATION_ID = 'a0o0P00000GZazOQAT'
+  LEASE_UP_PREFERENCE_ID = 'a0w0P00000OUJc3QAH' # preference is associated with application above
 
   SALE_APPLICATION_ID = 'a0o0P00000IWVdaQAH'
 
@@ -35,6 +36,10 @@ module ForceHelpers
 
   def lease_up_application_id
     LEASE_UP_APPLICATION_ID
+  end
+
+  def lease_up_preference_id
+    LEASE_UP_PREFERENCE_ID
   end
 
   def sale_application_id

--- a/spec/vcr/api/v1/applications_controller/update/failure.yml
+++ b/spec/vcr/api/v1/applications_controller/update/failure.yml
@@ -1,0 +1,104 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<<SALESFORCE_HOST>>/services/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=password&client_id=<<SALESFORCE_CLIENT_ID>>&client_secret=<<SALESFORCE_CLIENT_SECRET>>&username=<<SALESFORCE_USERNAME>>&password=<<SALESFORCE_PASSWORD>><<SALESFORCE_SECURITY_TOKEN>>
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 12 Dec 2019 00:28:51 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Cache-Control:
+      - no-cache,must-revalidate,max-age=0,no-store,private
+      Set-Cookie:
+      - BrowserId=XzY9DRx2EeqJhDO42rPdow;Path=/;Domain=.salesforce.com;Expires=Mon,
+        10-Feb-2020 00:28:51 GMT;Max-Age=5184000
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      X-Readonlymode:
+      - 'false'
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"<<ACCESS_TOKEN>>","instance_url":"https://sfhousing--Full.cs68.my.salesforce.com","id":"https://<<SALESFORCE_HOST>>/id/00D1D0000009nrYUAQ/005U00000066jl9IAA","token_type":"Bearer","issued_at":"1576110532092","signature":"N0Bwi7blj7V0dA9LaT8wsdDuuMNcC5jUsabv8WLwpXM="}'
+    http_version: 
+  recorded_at: Thu, 12 Dec 2019 00:28:52 GMT
+- request:
+    method: patch
+    uri: "<<SALESFORCE_INSTANCE_URL>>/services/data/v<<SALESFORCE_API_VERSION>>/sobjects/Application__c/invalid_id"
+    body:
+      encoding: UTF-8
+      string: '{"Total_Monthly_Rent__c":600.0}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <<ACCESS_TOKEN>>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Thu, 12 Dec 2019 00:28:52 GMT
+      Strict-Transport-Security:
+      - max-age=31536002; includeSubDomains
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="9n0izTnSRF+W4W4JTq51avSXkWhQB8duS2bxVLfzXsY="; pin-sha256="5kJvNEMw0KjrCAu7eXY5HZdvyCS13BbA0VJG1RSP91w=";
+        pin-sha256="njN4rRG+22dNXAi+yb8e3UMypgzPUPHlv4+foULwl1g="; max-age=86400;
+        includeSubDomains; report-uri="https://a.forcesslreports.com/hpkp-report/00D1D0000009nrYm";
+      Expect-Ct:
+      - max-age=86400, report-uri="https://a.forcesslreports.com/Expect-CT-report/00D1D0000009nrYm"
+      X-Robots-Tag:
+      - none
+      Cache-Control:
+      - no-cache,must-revalidate,max-age=0,no-store,private
+      Set-Cookie:
+      - BrowserId=X508JBx2EeqqOH1Ni0mt4g;Path=/;Domain=.salesforce.com;Expires=Mon,
+        10-Feb-2020 00:28:52 GMT;Max-Age=5184000
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=5632/5000000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '[{"errorCode":"NOT_FOUND","message":"Provided external ID field does
+        not exist or is not accessible: invalid_id"}]'
+    http_version: 
+  recorded_at: Thu, 12 Dec 2019 00:28:52 GMT
+recorded_with: VCR 5.0.0

--- a/spec/vcr/api/v1/applications_controller/update/success.yml
+++ b/spec/vcr/api/v1/applications_controller/update/success.yml
@@ -1,0 +1,99 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<<SALESFORCE_HOST>>/services/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=password&client_id=<<SALESFORCE_CLIENT_ID>>&client_secret=<<SALESFORCE_CLIENT_SECRET>>&username=<<SALESFORCE_USERNAME>>&password=<<SALESFORCE_PASSWORD>><<SALESFORCE_SECURITY_TOKEN>>
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 12 Dec 2019 00:27:37 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Cache-Control:
+      - no-cache,must-revalidate,max-age=0,no-store,private
+      Set-Cookie:
+      - BrowserId=MsgutRx2EeqMxQV0ZBtyXg;Path=/;Domain=.salesforce.com;Expires=Mon,
+        10-Feb-2020 00:27:37 GMT;Max-Age=5184000
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      X-Readonlymode:
+      - 'false'
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"<<ACCESS_TOKEN>>","instance_url":"https://sfhousing--Full.cs68.my.salesforce.com","id":"https://<<SALESFORCE_HOST>>/id/00D1D0000009nrYUAQ/005U00000066jl9IAA","token_type":"Bearer","issued_at":"1576110457407","signature":"qaVfMnXY0M9YmUGdoNlhxbGdpRSLAz/O8gf2Eosd/gg="}'
+    http_version: 
+  recorded_at: Thu, 12 Dec 2019 00:27:37 GMT
+- request:
+    method: patch
+    uri: "<<SALESFORCE_INSTANCE_URL>>/services/data/v<<SALESFORCE_API_VERSION>>/sobjects/Application__c/a0o0P00000Fv20MQAR"
+    body:
+      encoding: UTF-8
+      string: '{"Total_Monthly_Rent__c":600.0}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <<ACCESS_TOKEN>>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Thu, 12 Dec 2019 00:27:37 GMT
+      Strict-Transport-Security:
+      - max-age=31536002; includeSubDomains
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="9n0izTnSRF+W4W4JTq51avSXkWhQB8duS2bxVLfzXsY="; pin-sha256="5kJvNEMw0KjrCAu7eXY5HZdvyCS13BbA0VJG1RSP91w=";
+        pin-sha256="njN4rRG+22dNXAi+yb8e3UMypgzPUPHlv4+foULwl1g="; max-age=86400;
+        includeSubDomains; report-uri="https://a.forcesslreports.com/hpkp-report/00D1D0000009nrYm";
+      Expect-Ct:
+      - max-age=86400, report-uri="https://a.forcesslreports.com/Expect-CT-report/00D1D0000009nrYm"
+      X-Robots-Tag:
+      - none
+      Cache-Control:
+      - no-cache,must-revalidate,max-age=0,no-store,private
+      Set-Cookie:
+      - BrowserId=Mx1T6hx2EeqqOH1Ni0mt4g;Path=/;Domain=.salesforce.com;Expires=Mon,
+        10-Feb-2020 00:27:37 GMT;Max-Age=5184000
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=5629/5000000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 12 Dec 2019 00:27:38 GMT
+recorded_with: VCR 5.0.0

--- a/spec/vcr/api/v1/preferences_controller/update/failure.yml
+++ b/spec/vcr/api/v1/preferences_controller/update/failure.yml
@@ -1,0 +1,104 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<<SALESFORCE_HOST>>/services/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=password&client_id=<<SALESFORCE_CLIENT_ID>>&client_secret=<<SALESFORCE_CLIENT_SECRET>>&username=<<SALESFORCE_USERNAME>>&password=<<SALESFORCE_PASSWORD>><<SALESFORCE_SECURITY_TOKEN>>
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 12 Dec 2019 00:46:05 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Cache-Control:
+      - no-cache,must-revalidate,max-age=0,no-store,private
+      Set-Cookie:
+      - BrowserId=x1KyEBx4EeqwoMfs6tSiUA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        10-Feb-2020 00:46:05 GMT;Max-Age=5184000
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      X-Readonlymode:
+      - 'false'
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"<<ACCESS_TOKEN>>","instance_url":"https://sfhousing--Full.cs68.my.salesforce.com","id":"https://<<SALESFORCE_HOST>>/id/00D1D0000009nrYUAQ/005U00000066jl9IAA","token_type":"Bearer","issued_at":"1576111565806","signature":"MlR+Evecn5Ow7wTxd5WWEcEW4ys2HBcOBj12xuHor2o="}'
+    http_version: 
+  recorded_at: Thu, 12 Dec 2019 00:46:05 GMT
+- request:
+    method: patch
+    uri: "<<SALESFORCE_INSTANCE_URL>>/services/data/v<<SALESFORCE_API_VERSION>>/sobjects/Application_Preference__c/invalid_id"
+    body:
+      encoding: UTF-8
+      string: '{"Individual_preference__c":"Work in SF","Post_Lottery_Validation__c":"Unconfirmed"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <<ACCESS_TOKEN>>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Thu, 12 Dec 2019 00:46:06 GMT
+      Strict-Transport-Security:
+      - max-age=31536002; includeSubDomains
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="9n0izTnSRF+W4W4JTq51avSXkWhQB8duS2bxVLfzXsY="; pin-sha256="5kJvNEMw0KjrCAu7eXY5HZdvyCS13BbA0VJG1RSP91w=";
+        pin-sha256="njN4rRG+22dNXAi+yb8e3UMypgzPUPHlv4+foULwl1g="; max-age=86400;
+        includeSubDomains; report-uri="https://a.forcesslreports.com/hpkp-report/00D1D0000009nrYm";
+      Expect-Ct:
+      - max-age=86400, report-uri="https://a.forcesslreports.com/Expect-CT-report/00D1D0000009nrYm"
+      X-Robots-Tag:
+      - none
+      Cache-Control:
+      - no-cache,must-revalidate,max-age=0,no-store,private
+      Set-Cookie:
+      - BrowserId=x72B1xx4Eeq8Zj1AZtRHww;Path=/;Domain=.salesforce.com;Expires=Mon,
+        10-Feb-2020 00:46:06 GMT;Max-Age=5184000
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=5637/5000000
+      Content-Type:
+      - application/json;charset=UTF-8
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '[{"errorCode":"NOT_FOUND","message":"Provided external ID field does
+        not exist or is not accessible: invalid_id"}]'
+    http_version: 
+  recorded_at: Thu, 12 Dec 2019 00:46:06 GMT
+recorded_with: VCR 5.0.0

--- a/spec/vcr/api/v1/preferences_controller/update/success.yml
+++ b/spec/vcr/api/v1/preferences_controller/update/success.yml
@@ -1,0 +1,99 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://<<SALESFORCE_HOST>>/services/oauth2/token
+    body:
+      encoding: US-ASCII
+      string: grant_type=password&client_id=<<SALESFORCE_CLIENT_ID>>&client_secret=<<SALESFORCE_CLIENT_SECRET>>&username=<<SALESFORCE_USERNAME>>&password=<<SALESFORCE_PASSWORD>><<SALESFORCE_SECURITY_TOKEN>>
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 12 Dec 2019 00:46:04 GMT
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Cache-Control:
+      - no-cache,must-revalidate,max-age=0,no-store,private
+      Set-Cookie:
+      - BrowserId=xogPMhx4EeqiMBdnhw7usQ;Path=/;Domain=.salesforce.com;Expires=Mon,
+        10-Feb-2020 00:46:04 GMT;Max-Age=5184000
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      X-Readonlymode:
+      - 'false'
+      Content-Type:
+      - application/json;charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"<<ACCESS_TOKEN>>","instance_url":"https://sfhousing--Full.cs68.my.salesforce.com","id":"https://<<SALESFORCE_HOST>>/id/00D1D0000009nrYUAQ/005U00000066jl9IAA","token_type":"Bearer","issued_at":"1576111564273","signature":"4/1XoQ9HLrkyW1XQa3p7Jm719xEMToqOXeE6aXAhSjI="}'
+    http_version: 
+  recorded_at: Thu, 12 Dec 2019 00:46:04 GMT
+- request:
+    method: patch
+    uri: "<<SALESFORCE_INSTANCE_URL>>/services/data/v<<SALESFORCE_API_VERSION>>/sobjects/Application_Preference__c/a0w0P00000OUJc3QAH"
+    body:
+      encoding: UTF-8
+      string: '{"Individual_preference__c":"Work in SF","Post_Lottery_Validation__c":"Unconfirmed"}'
+    headers:
+      User-Agent:
+      - Faraday v0.15.4
+      Content-Type:
+      - application/json
+      Authorization:
+      - OAuth <<ACCESS_TOKEN>>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Thu, 12 Dec 2019 00:46:04 GMT
+      Strict-Transport-Security:
+      - max-age=31536002; includeSubDomains
+      Public-Key-Pins-Report-Only:
+      - pin-sha256="9n0izTnSRF+W4W4JTq51avSXkWhQB8duS2bxVLfzXsY="; pin-sha256="5kJvNEMw0KjrCAu7eXY5HZdvyCS13BbA0VJG1RSP91w=";
+        pin-sha256="njN4rRG+22dNXAi+yb8e3UMypgzPUPHlv4+foULwl1g="; max-age=86400;
+        includeSubDomains; report-uri="https://a.forcesslreports.com/hpkp-report/00D1D0000009nrYm";
+      Expect-Ct:
+      - max-age=86400, report-uri="https://a.forcesslreports.com/Expect-CT-report/00D1D0000009nrYm"
+      X-Robots-Tag:
+      - none
+      Cache-Control:
+      - no-cache,must-revalidate,max-age=0,no-store,private
+      Set-Cookie:
+      - BrowserId=xuHulBx4Eeq_-ovwkI-VyA;Path=/;Domain=.salesforce.com;Expires=Mon,
+        10-Feb-2020 00:46:04 GMT;Max-Age=5184000
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Sforce-Limit-Info:
+      - api-usage=5637/5000000
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 12 Dec 2019 00:46:05 GMT
+recorded_with: VCR 5.0.0


### PR DESCRIPTION
This PR also updates the way that we send preference updates to only include the total monthly rent if the preference is rent burdened