### PR TITLE
Fix invalid percent formatting bug #172688620

### DIFF
--- a/app/javascript/utils/form/validations.js
+++ b/app/javascript/utils/form/validations.js
@@ -61,19 +61,22 @@ const isValidEmail = (email) => {
   return true
 }
 
-const isValidCurrency = (value) => {
-  if (isNil(value)) {
+const isEmptyString = (value) => isNil(value) || value.length === 0
+
+export const isValidCurrency = (value) => {
+  if (isEmptyString(value)) {
     return true
   } else {
-    return !(/[^0-9$,.]/.test(value))
+    // Example passing values: 5, $5, 5.01, $5.01
+    return /^\$?[0-9,]+\.?[0-9]*$/.test(value)
   }
 }
 
 export const isValidPercent = (value) => {
-  if (isNil(value) || value.length === 0) {
+  if (isEmptyString(value)) {
     return true
   } else {
-    // Example passing values: 5, 10, 50%, 524%
+    // Example passing values: 5, 10.2, 50.50%, 524%
     return /^[0-9]+\.?[0-9]*%?$/.test(value)
   }
 }

--- a/app/javascript/utils/form/validations.js
+++ b/app/javascript/utils/form/validations.js
@@ -68,7 +68,7 @@ export const isValidCurrency = (value) => {
     return true
   } else {
     // Example passing values: 5, $5, 5.01, $5.01
-    return /^\$?[0-9,]+\.?[0-9]*$/.test(value)
+    return /^\$?[0-9]+[0-9,]*\.?[0-9]*$/.test(value)
   }
 }
 

--- a/app/javascript/utils/form/validations.js
+++ b/app/javascript/utils/form/validations.js
@@ -69,7 +69,7 @@ const isValidCurrency = (value) => {
   }
 }
 
-const isValidPercent = (value) => {
+export const isValidPercent = (value) => {
   if (isNil(value) || value.length === 0) {
     return true
   } else {

--- a/app/javascript/utils/formUtils.js
+++ b/app/javascript/utils/formUtils.js
@@ -1,5 +1,5 @@
 import { isObjectLike, isArray } from 'lodash'
-import { isValidPercent } from './form/validations'
+import { isValidPercent, isValidCurrency } from './form/validations'
 
 const toOption = (item) => {
   if (isArray(item)) {
@@ -22,7 +22,7 @@ const formatPrice = (value) => {
   let valueString = value.toString().replace(/[^.|\d]/g, '')
 
   // return value if value is not valid number
-  if (!isNaN(parseFloat(valueString))) {
+  if (isValidCurrency(value) && !isNaN(parseFloat(valueString))) {
     return '$' + parseFloat(valueString).toFixed(2).replace(/\d(?=(\d{3})+\.)/g, '$&,')
   } else {
     return value

--- a/app/javascript/utils/formUtils.js
+++ b/app/javascript/utils/formUtils.js
@@ -1,4 +1,5 @@
 import { isObjectLike, isArray } from 'lodash'
+import { isValidPercent } from './form/validations'
 
 const toOption = (item) => {
   if (isArray(item)) {
@@ -31,7 +32,7 @@ const formatPrice = (value) => {
 // Formats a number to percent in format: 50%, 5.5%, etc
 const formatPercent = (value) => {
   if (!value) return null
-  if (!isNaN(parseFloat(value))) {
+  if (isValidPercent(value) && !isNaN(parseFloat(value))) {
     // Outer parseFloat removes trailing zeros.
     return parseFloat(parseFloat(value).toFixed(3)) + '%'
   } else {

--- a/spec/javascript/utils/form/validations.test.js
+++ b/spec/javascript/utils/form/validations.test.js
@@ -160,12 +160,10 @@ describe('validate', () => {
         expect(validate.isValidCurrency(VALIDATION_MSG)('$2000.53')).toEqual(undefined)
         expect(validate.isValidCurrency(VALIDATION_MSG)('2,000')).toEqual(undefined)
       })
-      // Maybe validation should be enhanced for this case?
       test('when a currency string with too many commas is entered', () => {
         expect(validate.isValidCurrency(VALIDATION_MSG)('$2000,')).toEqual(undefined)
+        expect(validate.isValidCurrency(VALIDATION_MSG)('$2000,.52')).toEqual(undefined)
         expect(validate.isValidCurrency(VALIDATION_MSG)('$2,0,0,0')).toEqual(undefined)
-        expect(validate.isValidCurrency(VALIDATION_MSG)('$,,')).toEqual(undefined)
-        expect(validate.isValidCurrency(VALIDATION_MSG)(',')).toEqual(undefined)
       })
     })
     describe('fails validation', () => {
@@ -173,6 +171,13 @@ describe('validate', () => {
         expect(validate.isValidCurrency(VALIDATION_MSG)('$2000$')).toEqual(VALIDATION_MSG)
         expect(validate.isValidCurrency(VALIDATION_MSG)('$$2000')).toEqual(VALIDATION_MSG)
         expect(validate.isValidCurrency(VALIDATION_MSG)('$')).toEqual(VALIDATION_MSG)
+      })
+      test('when the value starts with a comma', () => {
+        expect(validate.isValidCurrency(VALIDATION_MSG)(',')).toEqual(VALIDATION_MSG)
+        expect(validate.isValidCurrency(VALIDATION_MSG)(',,')).toEqual(VALIDATION_MSG)
+        expect(validate.isValidCurrency(VALIDATION_MSG)(',1.00')).toEqual(VALIDATION_MSG)
+        expect(validate.isValidCurrency(VALIDATION_MSG)('$,')).toEqual(VALIDATION_MSG)
+        expect(validate.isValidCurrency(VALIDATION_MSG)('$,.00')).toEqual(VALIDATION_MSG)
       })
       test('when a string contains letters is entered', () => {
         expect(validate.isValidCurrency(VALIDATION_MSG)('zzz')).toEqual(VALIDATION_MSG)

--- a/spec/javascript/utils/form/validations.test.js
+++ b/spec/javascript/utils/form/validations.test.js
@@ -160,15 +160,20 @@ describe('validate', () => {
         expect(validate.isValidCurrency(VALIDATION_MSG)('$2000.53')).toEqual(undefined)
         expect(validate.isValidCurrency(VALIDATION_MSG)('2,000')).toEqual(undefined)
       })
-      // TODO: Enhance currency validation to exclude these cases.
-      test('when any string with $s and ,s is entered', () => {
-        expect(validate.isValidCurrency(VALIDATION_MSG)('$2000$')).toEqual(undefined)
-        expect(validate.isValidCurrency(VALIDATION_MSG)('$2,000,')).toEqual(undefined)
-        expect(validate.isValidCurrency(VALIDATION_MSG)('$')).toEqual(undefined)
+      // Maybe validation should be enhanced for this case?
+      test('when a currency string with too many commas is entered', () => {
+        expect(validate.isValidCurrency(VALIDATION_MSG)('$2000,')).toEqual(undefined)
+        expect(validate.isValidCurrency(VALIDATION_MSG)('$2,0,0,0')).toEqual(undefined)
+        expect(validate.isValidCurrency(VALIDATION_MSG)('$,,')).toEqual(undefined)
         expect(validate.isValidCurrency(VALIDATION_MSG)(',')).toEqual(undefined)
       })
     })
     describe('fails validation', () => {
+      test('when a non-currency string with $s and ,s is entered', () => {
+        expect(validate.isValidCurrency(VALIDATION_MSG)('$2000$')).toEqual(VALIDATION_MSG)
+        expect(validate.isValidCurrency(VALIDATION_MSG)('$$2000')).toEqual(VALIDATION_MSG)
+        expect(validate.isValidCurrency(VALIDATION_MSG)('$')).toEqual(VALIDATION_MSG)
+      })
       test('when a string contains letters is entered', () => {
         expect(validate.isValidCurrency(VALIDATION_MSG)('zzz')).toEqual(VALIDATION_MSG)
         expect(validate.isValidCurrency(VALIDATION_MSG)('2000.5z')).toEqual(VALIDATION_MSG)

--- a/spec/javascript/utils/formUtils.test.js
+++ b/spec/javascript/utils/formUtils.test.js
@@ -59,6 +59,8 @@ describe('formatPercent', () => {
   test('should leave improper values as-is', async () => {
     expect(formUtils.formatPercent('%')).toEqual('%')
     expect(formUtils.formatPercent('abc')).toEqual('abc')
+    expect(formUtils.formatPercent('5.5.5%')).toEqual('5.5.5%')
+    expect(formUtils.formatPercent('5..5')).toEqual('5..5')
   })
 
   test('should be empty if there is no value', async () => {

--- a/spec/javascript/utils/formUtils.test.js
+++ b/spec/javascript/utils/formUtils.test.js
@@ -15,6 +15,14 @@ describe('formatPrice', () => {
   test('should format 0 correctly', async () => {
     expect(formUtils.formatPrice('0')).toEqual('$0.00')
   })
+  test('should not modify currency values that are already formatted', async () => {
+    expect(formUtils.formatPrice('$11,000.00')).toEqual('$11,000.00')
+  })
+  test('should not format invalid currencies', async () => {
+    expect(formUtils.formatPrice('0.0.0')).toEqual('0.0.0')
+    expect(formUtils.formatPrice('abc')).toEqual('abc')
+    expect(formUtils.formatPrice('$$200')).toEqual('$$200')
+  })
 })
 
 describe('formatPercent', () => {


### PR DESCRIPTION
[pivotal ticket](https://www.pivotaltracker.com/n/projects/1405352/stories/172688620)

Previously, if a user entered 5.5.5 into the AMI percent field, the
formatter would auto-format it to be 5.5% because of how parseFloat()
behaves. This change makes it so that 5.5.5 will trigger a validation
error and will stop the page from saving successfully.

![- 2020-05-11 at 3 48 19 PM](https://user-images.githubusercontent.com/64036574/81619870-6615a880-939f-11ea-8cee-47911007c4d9.png)
