### PR TITLE
Separate AMI chart and year dropdowns #172864201

### DIFF
--- a/app/javascript/components/applications/application_form/formOptions.js
+++ b/app/javascript/components/applications/application_form/formOptions.js
@@ -1,11 +1,12 @@
-import { isEmpty, map } from 'lodash'
+const isNullOrEmptyString = (value) => value === undefined || value === null || value === ''
 
 const labelize = (options, attrs = {}, noPlaceholder = false) => {
-  if (isEmpty(options)) return []
+  if (options.length === 0) return []
 
   let emptyInitialOptionPresent =
-    isEmpty(options[0]) ||
-    (options[0].hasOwnProperty('value') && isEmpty(options[0].value)) || noPlaceholder
+    noPlaceholder ||
+    options[0] === '' ||
+    (options[0].hasOwnProperty('value') && isNullOrEmptyString(options[0].value))
 
   let labelizedOptions = []
   if (!emptyInitialOptionPresent) {
@@ -17,13 +18,13 @@ const labelize = (options, attrs = {}, noPlaceholder = false) => {
   }
 
   return labelizedOptions.concat(
-    map(options, (option) => (
-      {
+    options.map(option => {
+      return {
         value: option.hasOwnProperty('value') ? option.value : option,
-        label: option.label || option,
+        label: option.hasOwnProperty('label') ? option.label : option,
         ...(option.disabled && { disabled: option.disabled })
       }
-    ))
+    })
   )
 }
 

--- a/app/javascript/components/applications/application_form/formOptions.js
+++ b/app/javascript/components/applications/application_form/formOptions.js
@@ -1,10 +1,13 @@
+import { isEmpty } from 'lodash'
+
 const isNullOrEmptyString = (value) => value === undefined || value === null || value === ''
 
 const labelize = (options, attrs = {}, noPlaceholder = false) => {
-  if (options.length === 0) return []
+  if (isEmpty(options)) return []
 
   let emptyInitialOptionPresent =
     noPlaceholder ||
+    isEmpty(options) ||
     options[0] === '' ||
     (options[0].hasOwnProperty('value') && isNullOrEmptyString(options[0].value))
 

--- a/app/javascript/components/supplemental_application/SupplementalApplicationContainer.js
+++ b/app/javascript/components/supplemental_application/SupplementalApplicationContainer.js
@@ -65,13 +65,13 @@ const ConfirmedPreferencesSection = ({ application, applicationMembers, fileBase
   </ContentSection>
 )
 
-const ConfirmedHousehold = ({ listingAmiCharts, form, visited }) => (
+const ConfirmedHousehold = ({ listingAmiCharts, visited }) => (
   <ContentSection title='Confirmed Household'>
     <ContentSection.Sub title='Confirmed Reserved and Priority Units'>
       <ConfirmedUnits />
     </ContentSection.Sub>
     <ContentSection.Sub title='Confirmed Household Income'>
-      <ConfirmedHouseholdIncome listingAmiCharts={listingAmiCharts} form={form} visited={visited} />
+      <ConfirmedHouseholdIncome listingAmiCharts={listingAmiCharts} visited={visited} />
     </ContentSection.Sub>
   </ContentSection>
 )
@@ -181,7 +181,7 @@ const SupplementalApplicationContainer = ({ store }) => {
               confirmedPreferencesFailed={confirmedPreferencesFailed}
               form={form}
             />
-            <ConfirmedHousehold form={form} listingAmiCharts={listingAmiCharts} visited={visited} />
+            <ConfirmedHousehold listingAmiCharts={listingAmiCharts} visited={visited} />
             <LeaseInformationSection form={form} values={values} visited={visited} />
             <RentalAssistanceSection form={form} submitting={submitting} visited={visited} />
             <DemographicsSection />

--- a/app/javascript/components/supplemental_application/sections/ConfirmedHouseholdIncome.js
+++ b/app/javascript/components/supplemental_application/sections/ConfirmedHouseholdIncome.js
@@ -115,7 +115,7 @@ const ConfirmedHouseholdIncome = ({ listingAmiCharts, visited }) => {
             fieldName='ami_chart_year'
             label='AMI Chart Year'
             options={amiChartYears}
-            noPlaceholder={false} />
+            noPlaceholder={amiChartYears.length <= 1} />
         </FormGrid.Item>
       </FormGrid.Row>
     </React.Fragment>

--- a/app/javascript/components/supplemental_application/sections/ConfirmedHouseholdIncome.js
+++ b/app/javascript/components/supplemental_application/sections/ConfirmedHouseholdIncome.js
@@ -3,6 +3,8 @@ import { isNil, isString } from 'lodash'
 
 import FormGrid from '~/components/molecules/FormGrid'
 import { formatPercent } from '~/utils/utils'
+import getAmiChartYears from '~/utils/amiYearUtils'
+import formUtils from '~/utils/formUtils'
 
 import { YesNoRadioGroup, CurrencyField, PercentField, SelectField } from '~/utils/form/final_form/Field.js'
 import validate from '~/utils/form/validations'
@@ -28,47 +30,20 @@ export const getAmiPercent = ({income, ami}) => {
   return formatPercent(incomeFloat / Number(ami))
 }
 
-const ConfirmedHouseholdIncome = ({ listingAmiCharts, form, visited }) => {
-  const { values } = form.getState()
-  const currentAmiChartType = `${values.ami_chart_type} - ${values.ami_chart_year}`
-
+const ConfirmedHouseholdIncome = ({ listingAmiCharts, visited }) => {
   const [ amiChartTypes, setAmiChartTypes ] = useState([])
-  const [ selectedType, setSelectedType ] = useState(currentAmiChartType || '')
+  const [ amiChartYears, setAmiChartYears ] = useState([])
 
   useEffect(() => {
     const getAmiCharts = async () => {
       if (listingAmiCharts.length > 0) {
-        let chartTypes = listingAmiCharts.map((chart) => {
-          const value = `${chart.ami_chart_type} - ${chart.ami_chart_year}`
-          return { value, label: value }
-        })
-
-        if (chartTypes.length > 1) {
-          chartTypes.unshift({ value: null, label: 'Select One...' })
-        } else if (chartTypes.length === 1) {
-          const initialType = chartTypes[0]
-          setSelectedType(initialType)
-          setFormYearAndType(initialType.value)
-        }
-        setAmiChartTypes(chartTypes)
+        setAmiChartYears(formUtils.toOptions(getAmiChartYears(listingAmiCharts)))
+        setAmiChartTypes(formUtils.toOptions(listingAmiCharts.map(x => x.ami_chart_type)))
       }
     }
 
     getAmiCharts()
   }, [])
-
-  const setFormYearAndType = (combinedValue) => {
-    const idx = combinedValue.lastIndexOf(' - ')
-    const type = combinedValue.substr(0, idx)
-    const year = combinedValue.substr(idx).replace(' - ', '')
-    form.change('ami_chart_type', type)
-    form.change('ami_chart_year', year)
-  }
-
-  const handleAmiSelectChange = ({ target: { value } }) => {
-    setFormYearAndType(value)
-    setSelectedType(value)
-  }
 
   return (
     <React.Fragment>
@@ -131,10 +106,16 @@ const ConfirmedHouseholdIncome = ({ listingAmiCharts, form, visited }) => {
             id='ami_chart_type'
             fieldName='ami_chart_type'
             label='AMI Chart Type'
-            onChange={handleAmiSelectChange}
-            selectValue={selectedType}
             options={amiChartTypes}
-            noPlaceholder />
+            noPlaceholder={amiChartTypes.length <= 1} />
+        </FormGrid.Item>
+        <FormGrid.Item>
+          <SelectField
+            id='ami_chart_year'
+            fieldName='ami_chart_year'
+            label='AMI Chart Year'
+            options={amiChartYears}
+            noPlaceholder={false} />
         </FormGrid.Item>
       </FormGrid.Row>
     </React.Fragment>

--- a/app/javascript/utils/amiYearUtils.js
+++ b/app/javascript/utils/amiYearUtils.js
@@ -1,6 +1,6 @@
 import { concat, forEach, range } from 'lodash'
 
-// Example passing values: 1999, 2020, 0001
+// Example passing values: 1999, 2020, '0001'
 const isFourDigitYear = (value) => /^\d{4}$/.test(value)
 
 // Return true if the string is a valid year string and represents a year within 10 years (in past or future)
@@ -31,7 +31,8 @@ const getRangeOfAmiYears = (yearOptions, currentYear) => {
  * Ex: input charts with years [2018, 2019] will return [2018, 2019, 2020] if the current year is 2020.
  *
  * @param {*} listingAmiCharts list of objects with "ami_chart_year" attributes.
- * @param {*} currentYear optional param primarily used for stubbing in tests.
+ * @param {*} currentYear optional param primarily used for stubbing in tests. You should probably just use the default
+ *   value, which is the system's current year.
  */
 const getAmiChartYears = (listingAmiCharts, currentYear = (new Date()).getFullYear()) => {
   const fourDigitYearOptions = []

--- a/app/javascript/utils/amiYearUtils.js
+++ b/app/javascript/utils/amiYearUtils.js
@@ -1,0 +1,53 @@
+import { concat, forEach, range } from 'lodash'
+
+// Example passing values: 1999, 2020, 0001
+const isFourDigitYear = (value) => /^\d{4}$/.test(value)
+
+// Return true if the string is a valid year string and represents a year within 10 years (in past or future)
+const isRecentFourDigitYear = (value, currentYear) =>
+  isFourDigitYear(value) && Math.abs(value - currentYear) < 10
+
+/**
+ * Given an array of four digit years from unit ami chart options, sort and pad the array
+ * to include the current year, incrementing by one.
+ * ex: ([2018, 2019]) => [2018, 2019, 2020] if the current year is 2020.
+ *
+ * @param {*} yearOptions
+ * @param {*} currentYear the current, four digit year
+ */
+const getRangeOfAmiYears = (yearOptions, currentYear) => {
+  if (yearOptions.length === 0) return yearOptions
+
+  const minOption = Math.min(currentYear, ...yearOptions)
+  const maxOption = Math.max(currentYear, ...yearOptions)
+  return range(minOption, maxOption + 1)
+}
+
+/**
+ * Given a listing's AMI charts, get the list of year options for those charts. Note that the response list
+ * may be longer than the input list, as we include additional years incrementally until we reach the current
+ * date.
+ *
+ * Ex: input charts with years [2018, 2019] will return [2018, 2019, 2020] if the current year is 2020.
+ *
+ * @param {*} listingAmiCharts list of objects with "ami_chart_year" attributes.
+ * @param {*} currentYear optional param primarily used for stubbing in tests.
+ */
+const getAmiChartYears = (listingAmiCharts, currentYear = (new Date()).getFullYear()) => {
+  const fourDigitYearOptions = []
+  const otherYearOptions = []
+
+  forEach(listingAmiCharts, chart => {
+    const yearOption = chart.ami_chart_year
+
+    if (isRecentFourDigitYear(yearOption, currentYear)) {
+      fourDigitYearOptions.push(yearOption)
+    } else {
+      otherYearOptions.push(yearOption)
+    }
+  })
+
+  return concat(otherYearOptions, getRangeOfAmiYears(fourDigitYearOptions, currentYear))
+}
+
+export default getAmiChartYears

--- a/spec/javascript/components/applications/application_form/formOptions.test.js
+++ b/spec/javascript/components/applications/application_form/formOptions.test.js
@@ -28,5 +28,27 @@ describe('labelize', () => {
       const option = { value: 'test', label: 'test' }
       expect(labelize([option])[0]).toEqual(emptyOption)
     })
+    test('does not add an empty option with empty value', () => {
+      let option = { value: '', label: 'test' }
+      expect(labelize([option])[0]).toEqual(option)
+    })
+    test('does not add an empty option with first option as empty string', () => {
+      let option = ''
+      expect(labelize([option])[0]).toEqual({ value: '', label: '' })
+    })
+    test('does not add an empty option with noPlaceholder=true', () => {
+      const option = { value: 'test', label: 'test' }
+      expect(labelize([option], {}, true)[0]).toEqual(option)
+    })
+  })
+  describe('when all or part of an option is null', () => {
+    test('it keeps label as null', () => {
+      const option = { value: 'test', label: null }
+      expect(labelize([option], {}, true)[0]).toEqual(option)
+    })
+    test('it keeps value as null', () => {
+      const option = { value: null, label: 'label' }
+      expect(labelize([option], {}, true)[0]).toEqual(option)
+    })
   })
 })

--- a/spec/javascript/components/supplemental_application/__snapshots__/SupplementalApplicationPage.test.js.snap
+++ b/spec/javascript/components/supplemental_application/__snapshots__/SupplementalApplicationPage.test.js.snap
@@ -2759,45 +2759,11 @@ exports[`SupplementalApplicationPage Status Modal should render the status updat
                           </ContentSection>
                         </ConfirmedPreferencesSection>
                         <ConfirmedHousehold
-                          form={
-                            Object {
-                              "batch": [Function],
-                              "blur": [Function],
-                              "change": [Function],
-                              "destroyOnUnregister": false,
-                              "focus": [Function],
-                              "getFieldState": [Function],
-                              "getRegisteredFields": [Function],
-                              "getState": [Function],
-                              "initialize": [Function],
-                              "isValidationPaused": [Function],
-                              "mutators": Object {
-                                "concat": [Function],
-                                "insert": [Function],
-                                "move": [Function],
-                                "pop": [Function],
-                                "push": [Function],
-                                "remove": [Function],
-                                "removeBatch": [Function],
-                                "shift": [Function],
-                                "swap": [Function],
-                                "unshift": [Function],
-                                "update": [Function],
-                              },
-                              "pauseValidation": [Function],
-                              "registerField": [Function],
-                              "reset": [Function],
-                              "resetFieldState": [Function],
-                              "resumeValidation": [Function],
-                              "setConfig": [Function],
-                              "submit": [Function],
-                              "subscribe": [Function],
-                            }
-                          }
                           listingAmiCharts={Array []}
                           visited={
                             Object {
                               "ami_chart_type": false,
+                              "ami_chart_year": false,
                               "ami_percentage": false,
                               "applicant.marital_status": false,
                               "confirmed_household_annual_income": false,
@@ -3518,45 +3484,11 @@ exports[`SupplementalApplicationPage Status Modal should render the status updat
                                   className="app-inner inset-wide border-bottom"
                                 >
                                   <ConfirmedHouseholdIncome
-                                    form={
-                                      Object {
-                                        "batch": [Function],
-                                        "blur": [Function],
-                                        "change": [Function],
-                                        "destroyOnUnregister": false,
-                                        "focus": [Function],
-                                        "getFieldState": [Function],
-                                        "getRegisteredFields": [Function],
-                                        "getState": [Function],
-                                        "initialize": [Function],
-                                        "isValidationPaused": [Function],
-                                        "mutators": Object {
-                                          "concat": [Function],
-                                          "insert": [Function],
-                                          "move": [Function],
-                                          "pop": [Function],
-                                          "push": [Function],
-                                          "remove": [Function],
-                                          "removeBatch": [Function],
-                                          "shift": [Function],
-                                          "swap": [Function],
-                                          "unshift": [Function],
-                                          "update": [Function],
-                                        },
-                                        "pauseValidation": [Function],
-                                        "registerField": [Function],
-                                        "reset": [Function],
-                                        "resetFieldState": [Function],
-                                        "resumeValidation": [Function],
-                                        "setConfig": [Function],
-                                        "submit": [Function],
-                                        "subscribe": [Function],
-                                      }
-                                    }
                                     listingAmiCharts={Array []}
                                     visited={
                                       Object {
                                         "ami_chart_type": false,
+                                        "ami_chart_year": false,
                                         "ami_percentage": false,
                                         "applicant.marital_status": false,
                                         "confirmed_household_annual_income": false,
@@ -4032,9 +3964,7 @@ exports[`SupplementalApplicationPage Status Modal should render the status updat
                                               id="ami_chart_type"
                                               label="AMI Chart Type"
                                               noPlaceholder={true}
-                                              onChange={[Function]}
                                               options={Array []}
-                                              selectValue="undefined - undefined"
                                             >
                                               <Field
                                                 component="select"
@@ -4064,7 +3994,77 @@ exports[`SupplementalApplicationPage Status Modal should render the status updat
                                                     onBlur={[Function]}
                                                     onChange={[Function]}
                                                     onFocus={[Function]}
-                                                    value="undefined - undefined"
+                                                    value=""
+                                                  />
+                                                  <FieldError
+                                                    meta={
+                                                      Object {
+                                                        "active": false,
+                                                        "data": Object {},
+                                                        "dirty": false,
+                                                        "dirtySinceLastSubmit": false,
+                                                        "error": undefined,
+                                                        "initial": undefined,
+                                                        "invalid": false,
+                                                        "length": undefined,
+                                                        "modified": false,
+                                                        "pristine": true,
+                                                        "submitError": undefined,
+                                                        "submitFailed": false,
+                                                        "submitSucceeded": false,
+                                                        "submitting": false,
+                                                        "touched": false,
+                                                        "valid": true,
+                                                        "validating": false,
+                                                        "visited": false,
+                                                      }
+                                                    }
+                                                  />
+                                                </div>
+                                              </Field>
+                                            </SelectField>
+                                          </div>
+                                        </Component>
+                                        <Component>
+                                          <div
+                                            className="form-grid_item small-12 medium-6 large-3 column"
+                                          >
+                                            <SelectField
+                                              fieldName="ami_chart_year"
+                                              id="ami_chart_year"
+                                              label="AMI Chart Year"
+                                              noPlaceholder={false}
+                                              options={Array []}
+                                            >
+                                              <Field
+                                                component="select"
+                                                name="ami_chart_year"
+                                                parse={[Function]}
+                                              >
+                                                <div
+                                                  className="form-group"
+                                                >
+                                                  <Label
+                                                    fieldName="ami_chart_year"
+                                                    id="ami_chart_year"
+                                                    label="AMI Chart Year"
+                                                  >
+                                                    <label
+                                                      className="form-label"
+                                                      htmlFor="ami_chart_year"
+                                                      id="label-ami_chart_year"
+                                                    >
+                                                      AMI Chart Year
+                                                    </label>
+                                                  </Label>
+                                                  <select
+                                                    className=""
+                                                    id="ami_chart_year"
+                                                    name="ami_chart_year"
+                                                    onBlur={[Function]}
+                                                    onChange={[Function]}
+                                                    onFocus={[Function]}
+                                                    value=""
                                                   />
                                                   <FieldError
                                                     meta={
@@ -4300,6 +4300,7 @@ exports[`SupplementalApplicationPage Status Modal should render the status updat
                           visited={
                             Object {
                               "ami_chart_type": false,
+                              "ami_chart_year": false,
                               "ami_percentage": false,
                               "applicant.marital_status": false,
                               "confirmed_household_annual_income": false,
@@ -4404,6 +4405,7 @@ exports[`SupplementalApplicationPage Status Modal should render the status updat
                                     visited={
                                       Object {
                                         "ami_chart_type": false,
+                                        "ami_chart_year": false,
                                         "ami_percentage": false,
                                         "applicant.marital_status": false,
                                         "confirmed_household_annual_income": false,
@@ -4746,6 +4748,7 @@ exports[`SupplementalApplicationPage Status Modal should render the status updat
                                       visited={
                                         Object {
                                           "ami_chart_type": false,
+                                          "ami_chart_year": false,
                                           "ami_percentage": false,
                                           "applicant.marital_status": false,
                                           "confirmed_household_annual_income": false,
@@ -5615,6 +5618,7 @@ exports[`SupplementalApplicationPage Status Modal should render the status updat
                                     visited={
                                       Object {
                                         "ami_chart_type": false,
+                                        "ami_chart_year": false,
                                         "ami_percentage": false,
                                         "applicant.marital_status": false,
                                         "confirmed_household_annual_income": false,
@@ -5868,6 +5872,7 @@ exports[`SupplementalApplicationPage Status Modal should render the status updat
                           visited={
                             Object {
                               "ami_chart_type": false,
+                              "ami_chart_year": false,
                               "ami_percentage": false,
                               "applicant.marital_status": false,
                               "confirmed_household_annual_income": false,
@@ -6385,6 +6390,12 @@ exports[`SupplementalApplicationPage Status Modal should render the status updat
                                                       value={2}
                                                     >
                                                       <option
+                                                        key=""
+                                                        value=""
+                                                      >
+                                                        Select One...
+                                                      </option>
+                                                      <option
                                                         key="0"
                                                         value={0}
                                                       >
@@ -6533,6 +6544,12 @@ exports[`SupplementalApplicationPage Status Modal should render the status updat
                                                       onFocus={[Function]}
                                                       value={3}
                                                     >
+                                                      <option
+                                                        key=""
+                                                        value=""
+                                                      >
+                                                        Select One...
+                                                      </option>
                                                       <option
                                                         key="0"
                                                         value={0}
@@ -6688,6 +6705,12 @@ exports[`SupplementalApplicationPage Status Modal should render the status updat
                                                       onFocus={[Function]}
                                                       value={4}
                                                     >
+                                                      <option
+                                                        key=""
+                                                        value=""
+                                                      >
+                                                        Select One...
+                                                      </option>
                                                       <option
                                                         key="0"
                                                         value={0}
@@ -8737,22 +8760,77 @@ Array [
                   onBlur={[Function]}
                   onChange={[Function]}
                   onFocus={[Function]}
-                  value="undefined - undefined"
+                  value=""
                 >
                   <option
-                    value={null}
+                    value=""
                   >
                     Select One...
                   </option>
                   <option
-                    value="HUD Unadjusted - 2017"
+                    value="HUD Unadjusted"
                   >
-                    HUD Unadjusted - 2017
+                    HUD Unadjusted
                   </option>
                   <option
-                    value="Non-Hera - 2016"
+                    value="Non-Hera"
                   >
-                    Non-Hera - 2016
+                    Non-Hera
+                  </option>
+                </select>
+              </div>
+            </div>
+            <div
+              className="form-grid_item small-12 medium-6 large-3 column"
+            >
+              <div
+                className="form-group"
+              >
+                <label
+                  className="form-label"
+                  htmlFor="ami_chart_year"
+                  id="label-ami_chart_year"
+                >
+                  AMI Chart Year
+                </label>
+                <select
+                  className=""
+                  id="ami_chart_year"
+                  name="ami_chart_year"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  value=""
+                >
+                  <option
+                    value=""
+                  >
+                    Select One...
+                  </option>
+                  <option
+                    value={2016}
+                  >
+                    2016
+                  </option>
+                  <option
+                    value={2017}
+                  >
+                    2017
+                  </option>
+                  <option
+                    value={2018}
+                  >
+                    2018
+                  </option>
+                  <option
+                    value={2019}
+                  >
+                    2019
+                  </option>
+                  <option
+                    value={2020}
+                  >
+                    2020
                   </option>
                 </select>
               </div>
@@ -9126,6 +9204,11 @@ Array [
                     value={2}
                   >
                     <option
+                      value=""
+                    >
+                      Select One...
+                    </option>
+                    <option
                       value={0}
                     >
                       0
@@ -9204,6 +9287,11 @@ Array [
                     onFocus={[Function]}
                     value={3}
                   >
+                    <option
+                      value=""
+                    >
+                      Select One...
+                    </option>
                     <option
                       value={0}
                     >
@@ -9289,6 +9377,11 @@ Array [
                     onFocus={[Function]}
                     value={4}
                   >
+                    <option
+                      value=""
+                    >
+                      Select One...
+                    </option>
                     <option
                       value={0}
                     >

--- a/spec/javascript/components/supplemental_application/__snapshots__/SupplementalApplicationPage.test.js.snap
+++ b/spec/javascript/components/supplemental_application/__snapshots__/SupplementalApplicationPage.test.js.snap
@@ -4033,7 +4033,7 @@ exports[`SupplementalApplicationPage Status Modal should render the status updat
                                               fieldName="ami_chart_year"
                                               id="ami_chart_year"
                                               label="AMI Chart Year"
-                                              noPlaceholder={false}
+                                              noPlaceholder={true}
                                               options={Array []}
                                             >
                                               <Field

--- a/spec/javascript/e2e/SupplementalApplicationPage/confirmed_household.e2e.js
+++ b/spec/javascript/e2e/SupplementalApplicationPage/confirmed_household.e2e.js
@@ -18,6 +18,7 @@ describe('SupplementalApplicationPage confirmed household income section', () =>
     const finalHHAnnualSelector = '#form-hh_total_income_with_assets_annual'
     const amiPercentageSelector = '#ami_percentage'
     const amiChartTypeSelector = '#ami_chart_type'
+    const amiChartYearSelector = '#ami_chart_year'
 
     // Generate the values (with currency and non-currency strings)
     const hhAssetsValue = supplementalApplicationSteps.generateRandomCurrency()
@@ -40,7 +41,8 @@ describe('SupplementalApplicationPage confirmed household income section', () =>
     expect(await sharedSteps.getInputValue(page, confirmedAnnualSelector)).toEqual('$' + String(confirmedAnnualValue.float.toFixed(2)))
     expect(await sharedSteps.getInputValue(page, finalHHAnnualSelector)).toEqual('$' + String(finalHHAnnualValue.float.toFixed(2)))
     expect(await sharedSteps.getInputValue(page, amiPercentageSelector)).toEqual('5.55%')
-    expect(await sharedSteps.getInputValue(page, amiChartTypeSelector)).toEqual('HUD Unadjusted - 2018')
+    expect(await sharedSteps.getInputValue(page, amiChartTypeSelector)).toEqual('HUD Unadjusted')
+    expect(await sharedSteps.getInputValue(page, amiChartYearSelector)).toEqual('2018')
 
     await browser.close()
   }, DEFAULT_E2E_TIME_OUT)

--- a/spec/javascript/utils/amiYearUtils.test.js
+++ b/spec/javascript/utils/amiYearUtils.test.js
@@ -1,0 +1,90 @@
+import getAmiChartYears from '~/utils/amiYearUtils'
+
+const CurrentYear = '2020'
+
+const mockChart = (yearOption) => ({ ami_chart_year: yearOption })
+
+const mockCharts = (yearOptions) => yearOptions.map(chart => mockChart(chart))
+
+const getYearsWithMockOptions = (...yearOptions) => getAmiChartYears(mockCharts(yearOptions), CurrentYear)
+
+describe('getAmiChartYears', () => {
+  test('should return an empty list when passed an empty list', async () => {
+    expect(getYearsWithMockOptions()).toEqual([])
+  })
+
+  test('should handle non-digit options properly', async () => {
+    expect(getYearsWithMockOptions('a')).toEqual(['a'])
+    expect(getYearsWithMockOptions('a', 'b', 'c')).toEqual(['a', 'b', 'c'])
+  })
+
+  test('should handle non-recent year options properly', async () => {
+    expect(getYearsWithMockOptions('2000')).toEqual(['2000'])
+    expect(getYearsWithMockOptions(2000)).toEqual([2000])
+    expect(getYearsWithMockOptions(9999)).toEqual([9999])
+    expect(getYearsWithMockOptions(1)).toEqual([1])
+    expect(getYearsWithMockOptions(123456)).toEqual([123456])
+    expect(getYearsWithMockOptions(2000, 9999, 1)).toEqual([2000, 9999, 1])
+    expect(getYearsWithMockOptions(2030)).toEqual([2030])
+    expect(getYearsWithMockOptions(2010)).toEqual([2010])
+  })
+
+  test('should handle current year options properly', async () => {
+    expect(getYearsWithMockOptions('2020')).toEqual([2020])
+    expect(getYearsWithMockOptions('2020', 2020)).toEqual([2020])
+    expect(getYearsWithMockOptions('2020', 2020, 2020)).toEqual([2020])
+  })
+
+  test('should handle single recent past year options properly', async () => {
+    expect(getYearsWithMockOptions('2020')).toEqual([2020])
+    expect(getYearsWithMockOptions(2020)).toEqual([2020])
+    expect(getYearsWithMockOptions(2019)).toEqual([2019, 2020])
+    expect(getYearsWithMockOptions(2018)).toEqual([2018, 2019, 2020])
+    expect(getYearsWithMockOptions(2011)).toEqual([2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020])
+  })
+
+  test('should handle multiple recent past year options properly', async () => {
+    expect(getYearsWithMockOptions(2019, 2020)).toEqual([2019, 2020])
+    expect(getYearsWithMockOptions(2020, 2019)).toEqual([2019, 2020])
+    expect(getYearsWithMockOptions(2018, 2020)).toEqual([2018, 2019, 2020])
+    expect(getYearsWithMockOptions(2018, 2019)).toEqual([2018, 2019, 2020])
+    expect(getYearsWithMockOptions(2019, 2019, 2020)).toEqual([2019, 2020])
+    expect(getYearsWithMockOptions(2019, 2020, 2020)).toEqual([2019, 2020])
+  })
+
+  test('should handle single close future year options properly', async () => {
+    expect(getYearsWithMockOptions(2021)).toEqual([2020, 2021])
+    expect(getYearsWithMockOptions(2022)).toEqual([2020, 2021, 2022])
+    expect(getYearsWithMockOptions(2029)).toEqual([2020, 2021, 2022, 2023, 2024, 2025, 2026, 2027, 2028, 2029])
+  })
+
+  test('should handle multiple close future year options properly', async () => {
+    expect(getYearsWithMockOptions(2020, 2021)).toEqual([2020, 2021])
+    expect(getYearsWithMockOptions(2021, 2021)).toEqual([2020, 2021])
+    expect(getYearsWithMockOptions(2021, 2020)).toEqual([2020, 2021])
+    expect(getYearsWithMockOptions(2022, 2020)).toEqual([2020, 2021, 2022])
+    expect(getYearsWithMockOptions(2023, 2021)).toEqual([2020, 2021, 2022, 2023])
+  })
+
+  test('should handle a mix of past and future year options properly', async () => {
+    expect(getYearsWithMockOptions(2019, 2021)).toEqual([2019, 2020, 2021])
+    expect(getYearsWithMockOptions(2018, 2020, 2021)).toEqual([2018, 2019, 2020, 2021])
+    expect(getYearsWithMockOptions(2011, 2029)).toEqual([
+      2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020,
+      2021, 2022, 2023, 2024, 2025, 2026, 2027, 2028, 2029
+    ])
+  })
+
+  test('should sort non-year values before year values', async () => {
+    expect(getYearsWithMockOptions('non-year', 2019, 2021)).toEqual(['non-year', 2019, 2020, 2021])
+    expect(getYearsWithMockOptions(2019, 2021, 'non-year')).toEqual(['non-year', 2019, 2020, 2021])
+    expect(getYearsWithMockOptions(2019, 2021, 9999)).toEqual([9999, 2019, 2020, 2021])
+    expect(getYearsWithMockOptions(2019, '2021a', 2021, 9999)).toEqual(['2021a', 9999, 2019, 2020, 2021])
+  })
+
+  test('works for future years', async () => {
+    const futureYear = 2021
+    expect(getAmiChartYears(mockCharts(['non-year', 2019]), futureYear)).toEqual(['non-year', 2019, 2020, 2021])
+    expect(getAmiChartYears(mockCharts(['non-year', 2023]), futureYear)).toEqual(['non-year', 2021, 2022, 2023])
+  })
+})


### PR DESCRIPTION
[#172864201](https://www.pivotaltracker.com/n/projects/1405352/stories/172864201)

## Summary

Previously we combined AMI charts and years, but recently we found that
agents want to use more recent years than our options provided. This
change makes it so that agents will always be able to choose the current
year, even if it's not included in our AMI chart data. Additionally we
split up the year and AMI chart dropdowns because there is no longer a
1:1 mapping between the two.

### A couple decisions I made around how years are parsed

- I allow non-year strings and just append them to the beginning of the year dropdown
  - Why? I could see a case where there are options like "2020 adjusted" or something.
- I consider years more than 10 years away from the current year to be treated like non-years
  - Why? I didn't want something like "1000" to be entered and result in a dropdown with a thousand options


## Screencast
![amichartyears](https://user-images.githubusercontent.com/64036574/82248963-de2f2180-98fd-11ea-9ff4-d096c08818f8.gif)
