### PR TITLE
Automate filling in release description

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,28 @@ To run an individual test:
 
 `yarn test:all path/to/test`
 
+## Scripts
+
+### Release scripts
+More documentation for how these scripts are used during a release in the [partners release process doc](https://sfgovdt.jira.com/wiki/spaces/HOUS/pages/1900544029/Partners+Release+processes+template).
+
+#### 1. create_release_app
+Command: `yarn create_release_app`
+
+This script will:
+- Create a new branch named `release-<todays-date>`
+- Merge it with the latest main
+- Open a PR in a browser window
+
+#### 2. print_release_info
+Command: `yarn print_release_info -u <github-username> -t <github-access-token>`
+
+Instructions for how to get your github access token are printed by running `yarn print_release_info -h`
+
+This script will:
+- Print release tracker info you can paste into the [Release Tracker doc](https://docs.google.com/spreadsheets/d/1EUvw2ugaFprt8FxlCUa1yWATSn0KKo4FyRfBJWUwE3M/edit#gid=1500049656)
+- Output a URL that will create a draft release with description, title, tags, and base branch filled in
+
 ## Debugging
 
 You can debug all tests and Rails server in VS code.


### PR DESCRIPTION
I learned that you can pass title, tag, base, and body params to the releases/new URL to auto fill a release draft [[link](https://docs.github.com/en/github/administering-a-repository/automation-for-release-forms-with-query-parameters)]. This cuts down on the number of steps and risk of error when creating a new release draft.

Now the script will print this out:
```
--- Printing release description ---
New draft release url: https://github.com/SFDigitalServices/sf-dahlia-lap/releases/new?target=production&tag=v20200722&title=Release%20week%20of%2007%2f22&body=%0a%23%20Features%0a%0a%23%20Bugs%0a%0a%23%20Chores%0a%0a%23%20Other%0a-%20Create%20scripts%20to%20speed%20up%20release%20process%2c%20%28%23373%29%0a-%20Bump%20websocket-extensions%20from%200.1.4%20to%200.1.5%2c%20%28%23361%29%0a-%20release-07-09-2020%2c%20%28%23%29%0a-%20Bugs%2fchange%20to%20put%20request%20%5b172115886%5d%28https%3a%2f%2fwww.pivotaltracker.com%2fstory%2fshow%2f172115886%29%2c%20%28%23370%29
```

And when you open that url the draft will be auto populated:
<img src="https://user-images.githubusercontent.com/64036574/88213386-88cd0480-cc0d-11ea-89d3-cd9a8ddb483a.png" width="430" />

So you can just clean up the body and click submit draft.
