### PR TITLE
[rev3] Fix empty status items behavior

### DIFF
--- a/app/javascript/components/molecules/LeaseUpSidebar.js
+++ b/app/javascript/components/molecules/LeaseUpSidebar.js
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { isEmpty } from 'lodash'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 
@@ -38,8 +39,10 @@ const LeaseUpSidebar = ({ isLoading, statusItems, onSaveClicked, onChangeStatus,
   const [showingAllStatuses, setShowingAllStatuses] = useState(false)
 
   const currentStatus = getMostRecentStatus(statusItems)
+  const onShowHideStatusesToggled = () => setShowingAllStatuses(!showingAllStatuses)
+  const numberOfStatusesToDisplay = showingAllStatuses ? statusItems.length : MAX_UPDATES_TO_SHOW_DEFAULT
 
-  const sidebarButtons = (withMobileStyling) => (
+  const renderSidebarButtons = (withMobileStyling) => (
     <div className={withMobileStyling ? 'hide-large-up' : 'show-large-up'}>
       <LeaseUpSidebarButtons
         isLoading={isLoading}
@@ -51,24 +54,15 @@ const LeaseUpSidebar = ({ isLoading, statusItems, onSaveClicked, onChangeStatus,
       />
     </div>
   )
-  const onShowHideStatusesToggled = () => setShowingAllStatuses(!showingAllStatuses)
 
-  const numberOfStatusesToDisplay = showingAllStatuses ? statusItems.length : MAX_UPDATES_TO_SHOW_DEFAULT
-
-  const header = (title) => (
+  const renderStatusItemsSection = () => (
     <>
       <div className='padding-top--3x show-large-up'>
-        <ContentSection.SubHeader title={title} />
+        <ContentSection.SubHeader title='Status History' />
       </div>
       <div className='padding-top--half hide-large-up'>
-        <ContentSection.Header title={title} />
+        <ContentSection.Header title='Status History' />
       </div>
-    </>
-  )
-  return (
-    <div className='sidebar-content'>
-      {sidebarButtons(false)}
-      {header('Status History')}
       <StatusItems
         statusItems={statusItems}
         limit={numberOfStatusesToDisplay}
@@ -79,11 +73,17 @@ const LeaseUpSidebar = ({ isLoading, statusItems, onSaveClicked, onChangeStatus,
           onClick={onShowHideStatusesToggled}
         />
       )}
-      {sidebarButtons(true)}
+    </>
+  )
+
+  return (
+    <div className='sidebar-content'>
+      {renderSidebarButtons(false)}
+      {!isEmpty(statusItems) && renderStatusItemsSection()}
+      {renderSidebarButtons(true)}
     </div>
   )
 }
-
 LeaseUpSidebar.propTypes = {
   isLoading: PropTypes.bool,
   statusItems: PropTypes.arrayOf(PropTypes.shape(StatusItemShape)),

--- a/app/javascript/components/molecules/LeaseUpSidebarButtons.js
+++ b/app/javascript/components/molecules/LeaseUpSidebarButtons.js
@@ -48,7 +48,7 @@ const LeaseUpSidebarButtons = ({ status, withMobileStyling, isLoading, onSaveCli
 }
 
 LeaseUpSidebarButtons.propTypes = {
-  status: PropTypes.oneOf(LEASE_UP_STATUS_VALUES).isRequired,
+  status: PropTypes.oneOf(LEASE_UP_STATUS_VALUES),
   withMobileStyling: PropTypes.bool,
   isLoading: PropTypes.bool,
   onSaveClicked: PropTypes.func,
@@ -57,6 +57,7 @@ LeaseUpSidebarButtons.propTypes = {
 }
 
 LeaseUpSidebarButtons.defaultProps = {
+  status: null,
   withMobileStyling: false,
   isLoading: false,
   onSaveClicked: null,

--- a/spec/javascript/components/molecules/LeaseUpSidebar.test.js
+++ b/spec/javascript/components/molecules/LeaseUpSidebar.test.js
@@ -14,14 +14,12 @@ const getWrapper = (items, isLoading = false) => shallow(
 
 describe('LeaseUpSidebar', () => {
   describe('when not loading', () => {
-    // This is a state that should never really occur.
     test('should render with empty status items correctly', () => {
       const wrapper = getWrapper([])
       // two sidebar buttons components, one for mobile, one for desktop
       expect(wrapper.find(LeaseUpSidebarButtons)).toHaveLength(2)
       expect(wrapper.find(LeaseUpSidebarButtons).first().prop('status')).toEqual(null)
-      expect(wrapper.find(StatusItems)).toHaveLength(1)
-      expect(wrapper.find(StatusItems).prop('statusItems')).toHaveLength(0)
+      expect(wrapper.find(StatusItems)).toHaveLength(0)
     })
 
     test('should render with a single status item correctly', () => {

--- a/spec/javascript/components/supplemental_application/__snapshots__/SupplementalApplicationPage.test.js.snap
+++ b/spec/javascript/components/supplemental_application/__snapshots__/SupplementalApplicationPage.test.js.snap
@@ -17800,27 +17800,6 @@ Array [
                 </div>
               </div>
               <div
-                className="padding-top--3x show-large-up"
-              >
-                <h3
-                  className="app-card_h3 t-sans"
-                >
-                  Status History
-                </h3>
-              </div>
-              <div
-                className="padding-top--half hide-large-up"
-              >
-                <h2
-                  className="app-card_h2"
-                >
-                  Status History
-                </h2>
-              </div>
-              <div
-                className="status-items"
-              />
-              <div
                 className="hide-large-up"
               >
                 <div


### PR DESCRIPTION
This PR makes it to that applications with no status history don't show the "status history" header at all.