### PR TITLE
Fix parking space bug [DAH-147]

### DIFF
--- a/app/javascript/components/supplemental_application/sections/ParkingInformationInputs.js
+++ b/app/javascript/components/supplemental_application/sections/ParkingInformationInputs.js
@@ -10,8 +10,8 @@ const No = 'No'
 
 const ParkingInformationInputs = ({ form: { change, getFieldState }, values: { lease }, disabled = false }) => {
   const onChangeHasParkingSpace = ({ target: { value } }) => {
-    if (value === No) {
-      change(monthlyRentFieldName, '')
+    if (value !== Yes) {
+      change(monthlyRentFieldName, null)
     }
   }
 
@@ -25,12 +25,11 @@ const ParkingInformationInputs = ({ form: { change, getFieldState }, values: { l
         <FormGrid.Item>
           <SelectField
             label='BMR Parking Space Assigned?'
-            selectValue={hasParkingSpace ? Yes : No}
             onChange={onChangeHasParkingSpace}
             fieldName='lease.bmr_parking_space_assigned'
             options={[Yes, No]}
             disabled={disabled}
-            noPlaceholder />
+          />
         </FormGrid.Item>
         <FormGrid.Item>
           <CurrencyField

--- a/app/javascript/components/supplemental_application/sections/ParkingInformationInputs.js
+++ b/app/javascript/components/supplemental_application/sections/ParkingInformationInputs.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 
 import FormGrid from '~/components/molecules/FormGrid'
 import { SelectField, CurrencyField } from '~/utils/form/final_form/Field.js'
@@ -9,23 +9,24 @@ const Yes = 'Yes'
 const No = 'No'
 
 const ParkingInformationInputs = ({ form: { change, getFieldState }, values: { lease }, disabled = false }) => {
-  const [parkingSpaceAssigned, setParkingSpaceAssigned] = useState(lease && lease['monthly_parking_rent'] ? Yes : No)
-  const selectParkingSpaceAssigned = (event) => {
-    const { target: { value } } = event
-    setParkingSpaceAssigned(value)
+  const onChangeHasParkingSpace = ({ target: { value } }) => {
     if (value === No) {
       change(monthlyRentFieldName, '')
     }
   }
+
   const monthlyRentVisited = getFieldState(monthlyRentFieldName)?.visited
+
+  const hasParkingSpace = lease?.bmr_parking_space_assigned === Yes
+
   return (
     <>
       <FormGrid.Row>
         <FormGrid.Item>
           <SelectField
             label='BMR Parking Space Assigned?'
-            selectValue={parkingSpaceAssigned}
-            onChange={selectParkingSpaceAssigned}
+            selectValue={hasParkingSpace ? Yes : No}
+            onChange={onChangeHasParkingSpace}
             fieldName='lease.bmr_parking_space_assigned'
             options={[Yes, No]}
             disabled={disabled}
@@ -36,7 +37,7 @@ const ParkingInformationInputs = ({ form: { change, getFieldState }, values: { l
             label='Monthly Parking Cost'
             fieldName={monthlyRentFieldName}
             validation={validateLeaseCurrency}
-            disabled={disabled || parkingSpaceAssigned === No}
+            disabled={disabled || !hasParkingSpace}
             isDirty={monthlyRentVisited} />
         </FormGrid.Item>
       </FormGrid.Row>

--- a/spec/javascript/components/supplemental_application/__snapshots__/SupplementalApplicationPage.test.js.snap
+++ b/spec/javascript/components/supplemental_application/__snapshots__/SupplementalApplicationPage.test.js.snap
@@ -1434,7 +1434,7 @@ Array [
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
-                        value="Yes"
+                        value="No"
                       >
                         <option
                           value="Yes"

--- a/spec/javascript/components/supplemental_application/__snapshots__/SupplementalApplicationPage.test.js.snap
+++ b/spec/javascript/components/supplemental_application/__snapshots__/SupplementalApplicationPage.test.js.snap
@@ -1434,8 +1434,13 @@ Array [
                         onBlur={[Function]}
                         onChange={[Function]}
                         onFocus={[Function]}
-                        value="No"
+                        value=""
                       >
+                        <option
+                          value=""
+                        >
+                          Select One...
+                        </option>
                         <option
                           value="Yes"
                         >

--- a/spec/javascript/e2e/SupplementalApplicationPage/lease_information.e2e.js
+++ b/spec/javascript/e2e/SupplementalApplicationPage/lease_information.e2e.js
@@ -15,6 +15,7 @@ describe('SupplementalApplicationPage lease section', () => {
     await page.click('button#edit-lease-button')
 
     const rentSelector = '#form-lease\\.total_monthly_rent_without_parking'
+    const parkingDropdownSelector = '#form-lease\\.bmr_parking_space_assigned'
     const parkingRentSelector = '#form-lease\\.monthly_parking_rent'
     const tenantContributionSelector = '#form-lease\\.monthly_tenant_contribution'
 
@@ -24,6 +25,7 @@ describe('SupplementalApplicationPage lease section', () => {
     const tenantContributionValue = supplementalApplicationSteps.generateRandomCurrency()
 
     // Enter them
+    await sharedSteps.enterValue(page, parkingDropdownSelector, 'Yes')
     await sharedSteps.enterValue(page, rentSelector, rentValue.currency)
     await sharedSteps.enterValue(page, parkingRentSelector, parkingRentValue.currency)
     await sharedSteps.enterValue(page, tenantContributionSelector, tenantContributionValue.currency)


### PR DESCRIPTION
[DAH-147]

![- 2020-09-10 at 3 59 01 PM](https://user-images.githubusercontent.com/64036574/92820219-8fab0480-f37e-11ea-8fb5-295482994a58.png)

There was a bug in the parking space select where the value would always show up as "No" on reload, even if the backend value was "Yes". This was because we were using the presence of a related dollar value field to set this field on initial load, even though we should have been using the parking toggle itself.

I also removed the useState code since this doesn't actually need to be part of component state, we can just calculate the value in render.



[DAH-147]: https://sfgovdt.jira.com/browse/DAH-147