### PR TITLE
Connect new lease api [DAH-93]

### DIFF
--- a/app/javascript/components/supplemental_application/SupplementalApplicationContainer.js
+++ b/app/javascript/components/supplemental_application/SupplementalApplicationContainer.js
@@ -173,6 +173,9 @@ const SupplementalApplicationContainer = ({ store }) => {
     <Form
       onSubmit={values => onSubmit(convertPercentAndCurrency(values))}
       initialValues={application}
+      // Keep dirty on reinitialize ensures the whole form doesn't refresh
+      // when only a piece of it is saved (eg. when the lease is saved)
+      keepDirtyOnReinitialize
       validate={validateForm}
       mutators={{ ...arrayMutators }}
       render={({

--- a/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
+++ b/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
@@ -60,7 +60,6 @@ class SupplementalApplicationPage extends React.Component {
     leaseSectionState: getInitialLeaseState(this.props.application),
     showNewRentalAssistancePanel: false,
     showAddRentalAssistanceBtn: true,
-    rentalAssistanceLoading: false,
     rentalAssistances: this.props.rentalAssistances
   }
 
@@ -247,7 +246,7 @@ class SupplementalApplicationPage extends React.Component {
           application: {
             ...prevState.application,
             lease: response.lease,
-            rental_assistances: response.rental_assistances
+            rental_assistances: response.rentalAssistances
           },
           leaseSectionState: SHOW_LEASE_STATE
         }))
@@ -265,7 +264,7 @@ class SupplementalApplicationPage extends React.Component {
   }
 
   handleRentalAssistanceAction = (action) => {
-    this.setState({ rentalAssistanceLoading: true })
+    this.setState({ loading: true })
 
     return (...args) => {
       return action(...args).then(response => {
@@ -273,10 +272,9 @@ class SupplementalApplicationPage extends React.Component {
           return response
         } else {
           Alerts.error()
-          this.setState({ rentalAssistanceLoading: false })
           return false
         }
-      })
+      }).finally(() => this.setState({ loading: false }))
     }
   }
 
@@ -321,8 +319,7 @@ class SupplementalApplicationPage extends React.Component {
             rental_assistances: rentalAssistances
           },
           showNewRentalAssistancePanel: false,
-          showAddRentalAssistanceBtn: true,
-          rentalAssistanceLoading: false
+          showAddRentalAssistanceBtn: true
         }
       })
     }
@@ -346,8 +343,7 @@ class SupplementalApplicationPage extends React.Component {
             rental_assistances: rentalAssistances
           },
           showNewRentalAssistancePanel: false,
-          showAddRentalAssistanceBtn: true,
-          rentalAssistanceLoading: false
+          showAddRentalAssistanceBtn: true
         }
       })
     }

--- a/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
+++ b/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
@@ -445,12 +445,23 @@ class SupplementalApplicationPage extends React.Component {
   }
 }
 
-const mapProperties = ({ application, statusHistory, fileBaseUrl, units, availableUnits }) => {
+const mapProperties = ({
+  application,
+  availableUnits,
+  fileBaseUrl,
+  leaseSectionState,
+  statusHistory,
+  units
+}) => {
   return {
     application: setApplicationsDefaults(application),
     listing: application.listing,
     statusHistory: statusHistory,
-    onSubmit: (values) => updateApplication(values, application),
+    onSubmit: (values) => updateApplication(
+      values,
+      application,
+      shouldSaveLeaseOnApplicationSave(leaseSectionState)
+    ),
     fileBaseUrl: fileBaseUrl,
     units: units,
     availableUnits: availableUnits

--- a/app/javascript/components/supplemental_application/actions.js
+++ b/app/javascript/components/supplemental_application/actions.js
@@ -111,12 +111,12 @@ const updateUnsavedRentalAssistances = async (application, prevApplication) => {
   )
 }
 
-const createOrUpdateLease = async (lease, prevLease, applicantId, applicationId) => {
+const createOrUpdateLease = async (lease, prevLease, primaryApplicantContactId, applicationId) => {
   const isLeaseChanged = isChanged(prevLease, lease)
 
   const saveLeasePromise = isLeaseAlreadyCreated(lease)
-    ? () => apiService.updateLease(lease, applicantId, applicationId)
-    : () => apiService.createLease(lease, applicantId, applicationId)
+    ? () => apiService.updateLease(lease, primaryApplicantContactId, applicationId)
+    : () => apiService.createLease(lease, primaryApplicantContactId, applicationId)
 
   return performOrDefault(
     isLeaseChanged && !isEmpty(lease),

--- a/app/javascript/components/supplemental_application/actions.js
+++ b/app/javascript/components/supplemental_application/actions.js
@@ -19,6 +19,11 @@ const transformApplicationResponses = (lease, application, rentalAssistances) =>
   rental_assistances: rentalAssistances || []
 })
 
+const defaultLeaseResponse = (application) => ({
+  lease: application.lease,
+  rentalAssistances: application.rental_assistances
+})
+
 /**
  * Update any fields on the application that have been changed from
  * prevApplication. This action triggers multiple separate requests:
@@ -40,7 +45,7 @@ export const updateApplication = async (application, prevApplication, alsoSaveLe
   const saveLease = performOrDefault(
     alsoSaveLease,
     () => saveLeaseAndAssistances(application, prevApplication),
-    { lease: application.lease, rentalAssistances: application.rental_assistances }
+    defaultLeaseResponse(application)
   )
 
   return Promise.all([saveLease, updateApplicationIfChanged])
@@ -64,6 +69,10 @@ export const updateApplicationAndAddComment = async (application, prevApplicatio
 }
 
 export const saveLeaseAndAssistances = async (application, prevApplication) => {
+  if (isEmpty(application.lease)) {
+    return defaultLeaseResponse(application)
+  }
+
   return performInSequence(
     () => createOrUpdateLease(
       application.lease,

--- a/app/javascript/components/supplemental_application/actions.js
+++ b/app/javascript/components/supplemental_application/actions.js
@@ -20,8 +20,8 @@ const transformApplicationResponses = (lease, application, rentalAssistances) =>
 })
 
 const defaultLeaseResponse = (application) => ({
-  lease: application.lease,
-  rentalAssistances: application.rental_assistances
+  lease: application?.lease,
+  rentalAssistances: application?.rental_assistances
 })
 
 /**
@@ -45,12 +45,13 @@ export const updateApplication = async (application, prevApplication, alsoSaveLe
   const saveLease = performOrDefault(
     alsoSaveLease,
     () => saveLeaseAndAssistances(application, prevApplication),
-    defaultLeaseResponse(application)
+    defaultLeaseResponse(prevApplication)
   )
 
   return Promise.all([saveLease, updateApplicationIfChanged])
-    .then(([{ lease, rentalAssistances }, responseApplication]) =>
-      transformApplicationResponses(lease, responseApplication, rentalAssistances))
+    .then(([{ lease, rentalAssistances }, responseApplication]) => {
+      return transformApplicationResponses(lease, responseApplication, rentalAssistances)
+    })
 }
 
 export const createFieldUpdateComment = async (applicationId, status, comment, substatus) =>
@@ -63,7 +64,7 @@ export const updateApplicationAndAddComment = async (application, prevApplicatio
   })
 
   return performInSequence(
-    () => updateApplication(application, prevApplication),
+    () => updateApplication(application, prevApplication, alsoSaveLease),
     () => createFieldUpdateComment(prevApplication.id, status, comment, substatus)
   ).then(([appResponse, statusHistory]) => packageResponseData(appResponse, statusHistory))
 }

--- a/app/javascript/components/supplemental_application/actions.js
+++ b/app/javascript/components/supplemental_application/actions.js
@@ -2,9 +2,12 @@ import apiService from '~/apiService'
 import Alerts from '~/components/Alerts'
 import { isEmpty, find, isEqual, reject } from 'lodash'
 import { convertCurrency } from '~/utils/form/validations'
-import { filterChanged } from '~/utils/utils'
+import { isChanged, filterChanged } from '~/utils/utils'
 import { isLeaseAlreadyCreated } from '~/utils/leaseUtils'
-import { performInSequence } from '~/utils/promiseUtils'
+import {
+  performOrDefault,
+  performInSequence
+} from '~/utils/promiseUtils'
 
 /**
  * Combine lease, application, and rental assistances responses into a single
@@ -23,32 +26,32 @@ const transformApplicationResponses = (lease, application, rentalAssistances) =>
  * 2. A lease create or update request
  * 3. Multiple rental assistance create/update requests
  * 4. A rental assistance get request
- *
- * TODO: Don't create an empty lease in this function.
  */
-export const updateApplication = async (application, prevApplication) => {
-  const primaryApplicantContact = application.applicant && application.applicant.id
-  const applicationId = application['id']
+export const updateApplication = async (application, prevApplication, alsoSaveLease) => {
   const changedFields = filterChanged(prevApplication, application)
+  const isApplicationChanged = isChanged(prevApplication, application)
 
-  const leaseAndApplicationPromise = () =>
-    Promise.all([
-      updateOrCreateLease(application['lease'], primaryApplicantContact, applicationId),
-      apiService.submitApplication(changedFields, true)
-    ])
+  const updateApplicationIfChanged = performOrDefault(
+    isApplicationChanged,
+    () => apiService.submitApplication(changedFields, true),
+    application
+  )
 
-  return performInSequence(
-    // Lease must be saved first before rental assistances to avoid race condition.
-    leaseAndApplicationPromise,
-    () => updateUnsavedRentalAssistances(application, prevApplication)
-  ).then(([[lease, responseApplication], rentalAssistances]) =>
-    transformApplicationResponses(lease, responseApplication, rentalAssistances))
+  const saveLease = performOrDefault(
+    alsoSaveLease,
+    () => saveLeaseAndAssistances(application, prevApplication),
+    { lease: application.lease, rentalAssistances: application.rental_assistances }
+  )
+
+  return Promise.all([saveLease, updateApplicationIfChanged])
+    .then(([{ lease, rentalAssistances }, responseApplication]) =>
+      transformApplicationResponses(lease, responseApplication, rentalAssistances))
 }
 
 export const createFieldUpdateComment = async (applicationId, status, comment, substatus) =>
   apiService.createFieldUpdateComment(applicationId, status, comment, substatus)
 
-export const updateApplicationAndAddComment = async (application, prevApplication, status, comment, substatus) => {
+export const updateApplicationAndAddComment = async (application, prevApplication, status, comment, substatus, alsoSaveLease) => {
   const packageResponseData = (appResponse, statusHistory) => ({
     application: appResponse,
     statusHistory
@@ -58,6 +61,21 @@ export const updateApplicationAndAddComment = async (application, prevApplicatio
     () => updateApplication(application, prevApplication),
     () => createFieldUpdateComment(prevApplication.id, status, comment, substatus)
   ).then(([appResponse, statusHistory]) => packageResponseData(appResponse, statusHistory))
+}
+
+export const saveLeaseAndAssistances = async (application, prevApplication) => {
+  return performInSequence(
+    () => createOrUpdateLease(
+      application.lease,
+      prevApplication?.lease,
+      application.applicant?.id,
+      application.id
+    ),
+    () => updateUnsavedRentalAssistances(application, prevApplication)
+  ).then(([lease, rentalAssistances]) => ({
+    lease,
+    rentalAssistances
+  }))
 }
 
 const updateUnsavedRentalAssistances = async (application, prevApplication) => {
@@ -76,26 +94,25 @@ const updateUnsavedRentalAssistances = async (application, prevApplication) => {
     }
   })
 
-  return Promise.all(promises)
-    .then(() => apiService.getRentalAssistances(application.id))
+  return performOrDefault(
+    !isEmpty(promises),
+    () => Promise.all(promises).then(() => apiService.getRentalAssistances(application.id)),
+    rentalAssistances
+  )
 }
 
-export const createLease = async (lease, primaryApplicantContact, applicationId) =>
-  apiService.createLease(lease, primaryApplicantContact, applicationId)
+const createOrUpdateLease = async (lease, prevLease, applicantId, applicationId) => {
+  const isLeaseChanged = isChanged(prevLease, lease)
 
-export const updateLease = async (lease, primaryApplicantContact, applicationId) =>
-  apiService.updateLease(lease, primaryApplicantContact, applicationId)
+  const saveLeasePromise = isLeaseAlreadyCreated(lease)
+    ? () => apiService.updateLease(lease, applicantId, applicationId)
+    : () => apiService.createLease(lease, applicantId, applicationId)
 
-const updateOrCreateLease = async (lease, primaryApplicantContact, applicationId) => {
-  if (isEmpty(lease)) {
-    return lease
-  }
-
-  if (isLeaseAlreadyCreated(lease)) {
-    return updateLease(lease, primaryApplicantContact, applicationId)
-  } else {
-    return createLease(lease, primaryApplicantContact, applicationId)
-  }
+  return performOrDefault(
+    isLeaseChanged && !isEmpty(lease),
+    saveLeasePromise,
+    lease
+  )
 }
 
 export const getAMIAction = async ({ chartType, chartYear }) => {

--- a/app/javascript/components/supplemental_application/sections/Lease.js
+++ b/app/javascript/components/supplemental_application/sections/Lease.js
@@ -8,6 +8,7 @@ import InlineModal from '~/components/molecules/InlineModal'
 import formUtils from '~/utils/formUtils'
 import ParkingInformationInputs from './ParkingInformationInputs'
 import RentalAssistance from './RentalAssistance'
+import { convertPercentAndCurrency } from '../../../utils/form/validations'
 
 import { pluck } from '~/utils/utils'
 import { withContext } from '../context'
@@ -206,7 +207,7 @@ const Lease = ({ form, submitting, values, store }) => {
       <FormGrid.Row>
         {/* TODO: Wire up actions for buttons, set to disabled when loading */}
         <LeaseActions
-          onSave={handleSaveLease}
+          onSave={() => handleSaveLease(convertPercentAndCurrency(form.getState().values))}
           onCancelLeaseClick={handleCancelLeaseClick}
           onEditLeaseClick={handleEditLeaseClick}
           onDelete={handleDeleteLease}

--- a/app/javascript/components/supplemental_application/sections/Lease.js
+++ b/app/javascript/components/supplemental_application/sections/Lease.js
@@ -208,7 +208,7 @@ const Lease = ({ form, submitting, values, store }) => {
         {/* TODO: Wire up actions for buttons, set to disabled when loading */}
         <LeaseActions
           onSave={() => handleSaveLease(convertPercentAndCurrency(form.getState().values))}
-          onCancelLeaseClick={handleCancelLeaseClick}
+          onCancelLeaseClick={() => handleCancelLeaseClick(form)}
           onEditLeaseClick={handleEditLeaseClick}
           onDelete={handleDeleteLease}
           loading={loading}

--- a/app/javascript/components/supplemental_application/sections/Lease.js
+++ b/app/javascript/components/supplemental_application/sections/Lease.js
@@ -166,6 +166,7 @@ const Lease = ({ form, submitting, values, store }) => {
           form={form}
           submitting={submitting}
           disabled={disabled}
+          loading={loading}
         />
         <FormGrid.Row>
           <FormGrid.Item>

--- a/app/javascript/components/supplemental_application/sections/RentalAssistance.js
+++ b/app/javascript/components/supplemental_application/sections/RentalAssistance.js
@@ -107,7 +107,7 @@ const Panel = withContext(({ rentalAssistance, toggle, store, row, index, form }
     handleDeleteRentalAssistance,
     applicationMembers,
     handleCloseRentalAssistancePanel,
-    rentalAssistanceLoading
+    loading
   } = store
 
   const onSave = async (index, values) => {
@@ -138,7 +138,7 @@ const Panel = withContext(({ rentalAssistance, toggle, store, row, index, form }
       onDelete={onDelete}
       index={index}
       applicationMembers={applicationMembers}
-      loading={rentalAssistanceLoading}
+      loading={loading}
       form={form}
     />
   )
@@ -295,7 +295,7 @@ const RentalAssistance = ({
     handleSaveRentalAssistance,
     showAddRentalAssistanceBtn,
     hideAddRentalAssistanceBtn,
-    rentalAssistanceLoading
+    loading
   } = store
 
   const onSave = async (_, values) => {
@@ -326,7 +326,7 @@ const RentalAssistance = ({
             onSave={onSave}
             onClose={onClose}
             applicationMembers={applicationMembers}
-            loading={rentalAssistanceLoading}
+            loading={loading}
             values={{ type_of_assistance: null }}
             index={application.rental_assistances.length}
             form={form}
@@ -343,6 +343,7 @@ const RentalAssistance = ({
                 id='add-rental-assistance'
                 text='Add Rental Assistance'
                 small
+                disabled={loading}
                 onClick={handleOpenRentalAssistancePanel}
               />
             )}

--- a/app/javascript/components/supplemental_application/sections/RentalAssistance.js
+++ b/app/javascript/components/supplemental_application/sections/RentalAssistance.js
@@ -94,7 +94,7 @@ export const RentalAssistanceTable = ({
         rows={rows}
         expanderRenderer={expanderRenderer}
         expandedRowRenderer={expandedRowRenderer(rentalAssistances, form)}
-        closeAllRows={submitting}
+        closeAllRows={submitting || disabled}
         classes={['rental-assistances']}
       />
     </TableWrapper>

--- a/app/javascript/utils/promiseUtils.js
+++ b/app/javascript/utils/promiseUtils.js
@@ -32,3 +32,7 @@ export const performAllInSequence = (promiseFuncs) => {
 
   return promiseFuncs.reduce(reducer, Promise.resolve([]))
 }
+
+export const performOrDefault = async (condition, promiseFunc, defaultValue) => {
+  return condition ? promiseFunc() : defaultValue
+}

--- a/app/javascript/utils/promiseUtils.js
+++ b/app/javascript/utils/promiseUtils.js
@@ -33,6 +33,15 @@ export const performAllInSequence = (promiseFuncs) => {
   return promiseFuncs.reduce(reducer, Promise.resolve([]))
 }
 
+/**
+ * If condition is true, kick off the promise returned by promiseFunc and return it.
+ * If condition is false, return the default value wrapped in a promise.
+ * @param {boolean} condition the condition to test on
+ * @param {() => Promise} promiseFunc a function that resolves to a promise that
+ *   should only be fired if condition is true
+ * @param {Any} defaultValue the value that should be wrapped in a promise and returned
+ *   if condition is false.
+ */
 export const performOrDefault = async (condition, promiseFunc, defaultValue) => {
   return condition ? promiseFunc() : defaultValue
 }

--- a/app/javascript/utils/utils.js
+++ b/app/javascript/utils/utils.js
@@ -21,6 +21,10 @@ export const formatPercent = (value) => {
   return ((value * 100).toFixed(0) + '%')
 }
 
+export const isChanged = (prev, current) => {
+  return !isEqual(prev, current)
+}
+
 export const filterChanged = (prev, current) => {
   if (!prev) {
     return current

--- a/spec/javascript/components/supplemental_application/SupplementalApplicationPage.test.js
+++ b/spec/javascript/components/supplemental_application/SupplementalApplicationPage.test.js
@@ -100,8 +100,7 @@ describe('SupplementalApplicationPage', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  test('it doesnt send field that are not changed', async () => {
-    const payload = getMockApplication()
+  test('it doesnt send a request if nothing is changed', async () => {
     let wrapper
     await act(async () => {
       wrapper = mount(
@@ -112,8 +111,24 @@ describe('SupplementalApplicationPage', () => {
       )
     })
     await act(async () => { wrapper.find('form').first().simulate('submit') })
+    expect(mockSubmitApplication.mock.calls.length).toBe(0)
+  })
+
+  test('it only updates changed fields', async () => {
+    const payload = getMockApplication()
+    let wrapper
+    await act(async () => {
+      wrapper = mount(
+        <SupplementalApplicationPage
+          application={getMockApplication()}
+          statusHistory={statusHistory}
+          units={units} />
+      )
+    })
+    wrapper.find('#demographics-dependents select option[value=2]').simulate('change')
+    await act(async () => { wrapper.find('form').first().simulate('submit') })
     expect(mockSubmitApplication.mock.calls.length).toBe(1)
-    expect(mockSubmitApplication).toHaveBeenCalledWith({ id: payload.id })
+    expect(mockSubmitApplication).toHaveBeenCalledWith({ id: payload.id, number_of_dependents: 2 })
   })
 
   test('it saves demographics correctly', async () => {
@@ -358,6 +373,8 @@ describe('SupplementalApplicationPage', () => {
     })
 
     test('should send a null value for unit to API if selected', async () => {
+      wrapper.find('#edit-lease-button').first().simulate('click')
+
       // Select the value from the dropdown
       wrapper.find('[name="lease.unit"] select option[value=""]').simulate('change')
 

--- a/spec/javascript/components/supplemental_application/actions.test.js
+++ b/spec/javascript/components/supplemental_application/actions.test.js
@@ -1,4 +1,8 @@
-import { updateApplication, updateApplicationAndAddComment } from 'components/supplemental_application/actions'
+import {
+  saveLeaseAndAssistances,
+  updateApplication,
+  updateApplicationAndAddComment
+} from 'components/supplemental_application/actions'
 import supplementalApplication from '../../fixtures/supplemental_application'
 import { cloneDeep } from 'lodash'
 
@@ -88,6 +92,7 @@ describe('updateApplication', () => {
         expect(mockUpdateLeaseFn.mock.calls.length).toEqual(1)
       })
   })
+
   test('it should not submit lease to backend if application has no lease', async () => {
     const application = {
       'id': 'appID',
@@ -103,6 +108,52 @@ describe('updateApplication', () => {
         expect(response.id).toEqual(application.id)
         expect(response.lease).toEqual({})
         expect(mockSubmitAppFn.mock.calls.length).toEqual(1)
+        expect(mockCreateLeaseFn.mock.calls.length).toEqual(0)
+        expect(mockUpdateLeaseFn.mock.calls.length).toEqual(0)
+      })
+  })
+
+  test('it should not submit lease to backend if lease is unchanged', async () => {
+    const application = {
+      'id': 'appID',
+      'name': 'APP-12345',
+      'listing': {
+        'id': 'listingID'
+      },
+      'lease': {
+        'id': 'leaseID'
+      }
+    }
+
+    const prevApplication = {
+      ...application,
+      name: 'APP-prev'
+    }
+
+    const response = await updateApplication(application, prevApplication)
+    expect(response.id).toEqual(application.id)
+    expect(response.lease.id).toEqual('leaseID')
+    expect(mockSubmitAppFn.mock.calls.length).toEqual(1)
+    expect(mockCreateLeaseFn.mock.calls.length).toEqual(0)
+    expect(mockUpdateLeaseFn.mock.calls.length).toEqual(0)
+  })
+
+  test('it should not submit application to backend if application is unchanged', async () => {
+    const application = {
+      'id': 'appID',
+      'name': 'APP-12345',
+      'listing': {
+        'id': 'listingID'
+      },
+      'lease': {
+        'id': 'leaseID'
+      }
+    }
+
+    updateApplication(application, application)
+      .then(response => {
+        expect(response).toEqual(application)
+        expect(mockSubmitAppFn.mock.calls.length).toEqual(0)
         expect(mockCreateLeaseFn.mock.calls.length).toEqual(0)
         expect(mockUpdateLeaseFn.mock.calls.length).toEqual(0)
       })
@@ -151,10 +202,328 @@ describe('updateApplicationAndAddComment', () => {
         expect(response.application.id).toEqual(application.id)
         expect(response.statusHistory).toEqual(['status_history_item'])
         expect(mockSubmitAppFn.mock.calls.length).toEqual(1)
-        expect(mockSubmitAppFn.mock.calls.length).toEqual(0)
         expect(mockCreateLeaseFn.mock.calls.length).toEqual(1)
         expect(mockCreateFieldUpdateCommentFn.mock.calls.length).toEqual(1)
         expect(mockCreateFieldUpdateCommentFn).toHaveBeenCalledWith('appID', 'Approved')
       })
+  })
+})
+
+describe('saveLeaseAndAssistances', () => {
+  const assistance1 = { id: 'rentalAssistanceID1', type: 'rentalAssistanceType' }
+  const assistanceNoId = { type: 'rentalAssistanceType' }
+
+  const leaseWithId = { id: 'leaseId' }
+  const leaseWithId2 = { id: 'leaseId2' }
+  const leaseNoId = { otherLeaseField: 'otherLeaseField' }
+
+  const application = { id: 'appID' }
+
+  const appWith = ({ lease, assistances }) => ({
+    ...application,
+    lease,
+    rental_assistances: assistances
+  })
+
+  describe('when the current application doesnt have a lease or assistances', () => {
+    const currentApp = appWith({ lease: {}, assistances: [] })
+    describe('when the previous application doesnt have a lease or assistances', () => {
+      const prevApp = appWith({ lease: {}, assistances: [] })
+      beforeEach(async () => {
+        await saveLeaseAndAssistances(currentApp, prevApp)
+      })
+
+      test('it does not save anything', async () => {
+        expect(mockCreateLeaseFn.mock.calls.length).toEqual(0)
+        expect(mockUpdateLeaseFn.mock.calls.length).toEqual(0)
+        expect(mockCreateRentalFn.mock.calls.length).toEqual(0)
+        expect(mockUpdateRentalFn.mock.calls.length).toEqual(0)
+        expect(mockGetRentalAssistancesFn.mock.calls.length).toEqual(0)
+      })
+    })
+
+    describe('when the previous application does have a lease', () => {
+      describe('when the previous application does not have assistances', () => {
+        const prevApp = appWith({ lease: leaseWithId, assistances: [] })
+        beforeEach(async () => {
+          await saveLeaseAndAssistances(currentApp, prevApp)
+        })
+
+        test('it does not save anything', async () => {
+          expect(mockCreateLeaseFn.mock.calls.length).toEqual(0)
+          expect(mockUpdateLeaseFn.mock.calls.length).toEqual(0)
+          expect(mockCreateRentalFn.mock.calls.length).toEqual(0)
+          expect(mockUpdateRentalFn.mock.calls.length).toEqual(0)
+          expect(mockGetRentalAssistancesFn.mock.calls.length).toEqual(0)
+        })
+      })
+
+      describe('when the previous application does have assistances', () => {
+        const prevApp = appWith({ lease: leaseWithId, assistances: [assistance1] })
+        beforeEach(async () => {
+          await saveLeaseAndAssistances(currentApp, prevApp)
+        })
+
+        test('it does not save anything', async () => {
+          expect(mockCreateLeaseFn.mock.calls.length).toEqual(0)
+          expect(mockUpdateLeaseFn.mock.calls.length).toEqual(0)
+          expect(mockCreateRentalFn.mock.calls.length).toEqual(0)
+          expect(mockUpdateRentalFn.mock.calls.length).toEqual(0)
+          expect(mockGetRentalAssistancesFn.mock.calls.length).toEqual(0)
+        })
+      })
+    })
+  })
+
+  describe('when the current application has a lease with an id and no assistances', () => {
+    const currentApp = appWith({ lease: leaseWithId, assistances: [] })
+
+    describe('when the other app is null', () => {
+      const prevApp = null
+      let response
+
+      beforeEach(async () => {
+        response = await saveLeaseAndAssistances(currentApp, prevApp)
+      })
+
+      it('only triggers a lease update request', () => {
+        expect(mockCreateLeaseFn.mock.calls.length).toEqual(0)
+        expect(mockUpdateLeaseFn.mock.calls.length).toEqual(1)
+        expect(mockCreateRentalFn.mock.calls.length).toEqual(0)
+        expect(mockUpdateRentalFn.mock.calls.length).toEqual(0)
+        expect(mockGetRentalAssistancesFn.mock.calls.length).toEqual(0)
+      })
+
+      it('returns the correct lease response', () => {
+        expect(response.lease).toEqual(leaseWithId)
+      })
+
+      it('returns the correct assistances response', () => {
+        expect(response.rentalAssistances).toEqual([])
+      })
+    })
+
+    describe('when the other app has no lease or assistances', () => {
+      const prevApp = appWith({ lease: {}, assistances: [] })
+      let response
+
+      beforeEach(async () => {
+        response = await saveLeaseAndAssistances(currentApp, prevApp)
+      })
+
+      it('only triggers a lease update request', () => {
+        expect(mockCreateLeaseFn.mock.calls.length).toEqual(0)
+        expect(mockUpdateLeaseFn.mock.calls.length).toEqual(1)
+        expect(mockCreateRentalFn.mock.calls.length).toEqual(0)
+        expect(mockUpdateRentalFn.mock.calls.length).toEqual(0)
+        expect(mockGetRentalAssistancesFn.mock.calls.length).toEqual(0)
+      })
+
+      it('returns the correct lease response', () => {
+        expect(response.lease).toEqual(leaseWithId)
+      })
+
+      it('returns the correct assistances response', () => {
+        expect(response.rentalAssistances).toEqual([])
+      })
+    })
+
+    describe('when the other app has the same lease and no assistances', () => {
+      const prevApp = appWith({ lease: leaseWithId, assistances: [] })
+      let response
+
+      beforeEach(async () => {
+        response = await saveLeaseAndAssistances(currentApp, prevApp)
+      })
+
+      it('does not trigger any requests', () => {
+        expect(mockCreateLeaseFn.mock.calls.length).toEqual(0)
+        expect(mockUpdateLeaseFn.mock.calls.length).toEqual(0)
+        expect(mockCreateRentalFn.mock.calls.length).toEqual(0)
+        expect(mockUpdateRentalFn.mock.calls.length).toEqual(0)
+        expect(mockGetRentalAssistancesFn.mock.calls.length).toEqual(0)
+      })
+
+      it('returns the correct lease response', () => {
+        expect(response.lease).toEqual(leaseWithId)
+      })
+
+      it('returns the correct assistances response', () => {
+        expect(response.rentalAssistances).toEqual([])
+      })
+    })
+
+    describe('when the other app has a different lease and no assistances', () => {
+      const prevApp = appWith({ lease: leaseWithId2, assistances: [] })
+      let response
+
+      beforeEach(async () => {
+        response = await saveLeaseAndAssistances(currentApp, prevApp)
+      })
+
+      it('only updates the lease', () => {
+        expect(mockCreateLeaseFn.mock.calls.length).toEqual(0)
+        expect(mockUpdateLeaseFn.mock.calls.length).toEqual(1)
+        expect(mockCreateRentalFn.mock.calls.length).toEqual(0)
+        expect(mockUpdateRentalFn.mock.calls.length).toEqual(0)
+        expect(mockGetRentalAssistancesFn.mock.calls.length).toEqual(0)
+      })
+
+      it('returns the correct lease response', () => {
+        expect(response.lease).toEqual(leaseWithId)
+      })
+
+      it('returns the correct assistances response', () => {
+        expect(response.rentalAssistances).toEqual([])
+      })
+    })
+  })
+
+  describe('when the current application has a lease without an id', () => {
+    const currentApp = appWith({ lease: leaseNoId, assistances: [] })
+
+    describe('when the other app is null', () => {
+      const prevApp = null
+      let response
+
+      beforeEach(async () => {
+        response = await saveLeaseAndAssistances(currentApp, prevApp)
+      })
+
+      it('only triggers a lease create request', () => {
+        expect(mockCreateLeaseFn.mock.calls.length).toEqual(1)
+        expect(mockUpdateLeaseFn.mock.calls.length).toEqual(0)
+        expect(mockCreateRentalFn.mock.calls.length).toEqual(0)
+        expect(mockUpdateRentalFn.mock.calls.length).toEqual(0)
+        expect(mockGetRentalAssistancesFn.mock.calls.length).toEqual(0)
+      })
+
+      it('returns the correct lease response', () => {
+        expect(response.lease).toEqual(leaseNoId)
+      })
+
+      it('returns the correct assistances response', () => {
+        expect(response.rentalAssistances).toEqual([])
+      })
+    })
+
+    describe('when the other app has no lease or assistances', () => {
+      const prevApp = appWith({ lease: {}, assistances: [] })
+      let response
+
+      beforeEach(async () => {
+        response = await saveLeaseAndAssistances(currentApp, prevApp)
+      })
+
+      it('only triggers a lease create request', () => {
+        expect(mockCreateLeaseFn.mock.calls.length).toEqual(1)
+        expect(mockUpdateLeaseFn.mock.calls.length).toEqual(0)
+        expect(mockCreateRentalFn.mock.calls.length).toEqual(0)
+        expect(mockUpdateRentalFn.mock.calls.length).toEqual(0)
+        expect(mockGetRentalAssistancesFn.mock.calls.length).toEqual(0)
+      })
+
+      it('returns the correct lease response', () => {
+        expect(response.lease).toEqual(leaseNoId)
+      })
+
+      it('returns the correct assistances response', () => {
+        expect(response.rentalAssistances).toEqual([])
+      })
+    })
+
+    describe('when the other app has the same lease and no assistances', () => {
+      const prevApp = appWith({ lease: leaseNoId, assistances: [] })
+      let response
+
+      beforeEach(async () => {
+        response = await saveLeaseAndAssistances(currentApp, prevApp)
+      })
+
+      it('does not trigger any requests', () => {
+        expect(mockCreateLeaseFn.mock.calls.length).toEqual(0)
+        expect(mockUpdateLeaseFn.mock.calls.length).toEqual(0)
+        expect(mockCreateRentalFn.mock.calls.length).toEqual(0)
+        expect(mockUpdateRentalFn.mock.calls.length).toEqual(0)
+        expect(mockGetRentalAssistancesFn.mock.calls.length).toEqual(0)
+      })
+
+      it('returns the correct lease response', () => {
+        expect(response.lease).toEqual(leaseNoId)
+      })
+
+      it('returns the correct assistances response', () => {
+        expect(response.rentalAssistances).toEqual([])
+      })
+    })
+
+    describe('when the other app has a different lease and no assistances', () => {
+      const prevApp = appWith({ lease: leaseWithId2, assistances: [] })
+      let response
+
+      beforeEach(async () => {
+        response = await saveLeaseAndAssistances(currentApp, prevApp)
+      })
+
+      it('only creates the new lease', () => {
+        expect(mockCreateLeaseFn.mock.calls.length).toEqual(1)
+        expect(mockUpdateLeaseFn.mock.calls.length).toEqual(0)
+        expect(mockCreateRentalFn.mock.calls.length).toEqual(0)
+        expect(mockUpdateRentalFn.mock.calls.length).toEqual(0)
+        expect(mockGetRentalAssistancesFn.mock.calls.length).toEqual(0)
+      })
+
+      it('returns the correct lease response', () => {
+        expect(response.lease).toEqual(leaseNoId)
+      })
+
+      it('returns the correct assistances response', () => {
+        expect(response.rentalAssistances).toEqual([])
+      })
+    })
+  })
+
+  describe('when the current application has a new assistance', () => {
+    const currentApp = appWith({ lease: leaseWithId, assistances: [assistanceNoId, assistance1] })
+    const prevApp = appWith({ lease: leaseWithId, assistances: [assistance1] })
+    let response
+
+    beforeEach(async () => {
+      response = await saveLeaseAndAssistances(currentApp, prevApp)
+    })
+
+    it('only triggers an assistance create request', () => {
+      expect(mockCreateLeaseFn.mock.calls.length).toEqual(0)
+      expect(mockUpdateLeaseFn.mock.calls.length).toEqual(0)
+      expect(mockCreateRentalFn.mock.calls.length).toEqual(1)
+      expect(mockUpdateRentalFn.mock.calls.length).toEqual(0)
+      expect(mockGetRentalAssistancesFn.mock.calls.length).toEqual(1)
+    })
+
+    it('returns the correct lease response', () => {
+      expect(response.lease).toEqual(leaseWithId)
+    })
+  })
+
+  describe('when the current application has an edited assistance', () => {
+    const currentApp = appWith({ lease: leaseWithId, assistances: [{ ...assistance1, newField: 'newFieldValue' }] })
+    const prevApp = appWith({ lease: leaseWithId, assistances: [assistance1] })
+    let response
+
+    beforeEach(async () => {
+      response = await saveLeaseAndAssistances(currentApp, prevApp)
+    })
+
+    it('only triggers an assistance create request', () => {
+      expect(mockCreateLeaseFn.mock.calls.length).toEqual(0)
+      expect(mockUpdateLeaseFn.mock.calls.length).toEqual(0)
+      expect(mockCreateRentalFn.mock.calls.length).toEqual(0)
+      expect(mockUpdateRentalFn.mock.calls.length).toEqual(1)
+      expect(mockGetRentalAssistancesFn.mock.calls.length).toEqual(1)
+    })
+
+    it('returns the correct lease response', () => {
+      expect(response.lease).toEqual(leaseWithId)
+    })
   })
 })

--- a/spec/javascript/components/supplemental_application/sections/RentalAssistance.test.js
+++ b/spec/javascript/components/supplemental_application/sections/RentalAssistance.test.js
@@ -12,6 +12,7 @@ import {
 import {
   InputField
 } from '~/utils/form/final_form/Field'
+import ExpandableTable from '~/components/molecules/ExpandableTable'
 
 const baseContext = {
   application: { rental_assistances: [] },
@@ -64,6 +65,51 @@ describe('RentalAssistance', () => {
     const wrapper = getWrapper(context)
     expect(wrapper.find(RentalAssistanceTable)).toHaveLength(1)
     expect(wrapper.find(RentalAssistanceForm)).toHaveLength(1)
+  })
+})
+
+describe('RentalAssistanceTable', () => {
+  const getWrapper = ({ submitting = false, disabled = false }) => {
+    const context = cloneDeep(baseContext)
+    context.application.rental_assistances = [rentalAssistance]
+
+    return withForm(
+      context,
+      (form) => (
+        <RentalAssistanceTable
+          form={form}
+          rentalAssistances={[rentalAssistance]}
+          applicationMembers={[]}
+          submitting={submitting}
+          disabled={disabled}
+        />
+      )
+    )
+  }
+
+  test('should render an ExpanderTable', () => {
+    const wrapper = getWrapper({})
+    expect(wrapper.find(ExpandableTable)).toHaveLength(1)
+  })
+
+  test('should not close all panels if not submitting or disabled', () => {
+    const wrapper = getWrapper({})
+    expect(wrapper.find(ExpandableTable).prop('closeAllRows')).toBeFalsy()
+  })
+
+  test('should close all panels when submitting', () => {
+    const wrapper = getWrapper({ submitting: true })
+    expect(wrapper.find(ExpandableTable).prop('closeAllRows')).toBeTruthy()
+  })
+
+  test('should close all panels when disabled', () => {
+    const wrapper = getWrapper({ disabled: true })
+    expect(wrapper.find(ExpandableTable).prop('closeAllRows')).toBeTruthy()
+  })
+
+  test('should close all panels when submitting and disabled', () => {
+    const wrapper = getWrapper({ disabled: true, submitting: true })
+    expect(wrapper.find(ExpandableTable).prop('closeAllRows')).toBeTruthy()
   })
 })
 

--- a/spec/javascript/utils/utils.test.js
+++ b/spec/javascript/utils/utils.test.js
@@ -1,5 +1,5 @@
 import { convertCurrency } from '~/utils/form/validations'
-import { filterChanged } from '~/utils/utils'
+import { filterChanged, isChanged } from '~/utils/utils'
 import { cloneDeep } from 'lodash'
 
 const defaultFormObject = {
@@ -25,6 +25,29 @@ const object = {
     string: 'str'
   }
 }
+
+describe('isChanged', () => {
+  test('should return false when both objects are equal', () => {
+    expect(isChanged(undefined, undefined)).toBeFalsy()
+    expect(isChanged(null, null)).toBeFalsy()
+    expect(isChanged(null, undefined)).toBeFalsy()
+    expect(isChanged({}, {})).toBeFalsy()
+    expect(isChanged({ a: 'a' }, { a: 'a' })).toBeFalsy()
+    expect(isChanged({ a: { b: 'b' } }, { a: { b: 'b' } })).toBeFalsy()
+    expect(isChanged({ a: [{ b: 'b' }] }, { a: [{ b: 'b' }] })).toBeFalsy()
+  })
+
+  test('should return true when both objects are unequal', () => {
+    expect(isChanged(undefined, {})).toBeTruthy()
+    expect(isChanged(null, {})).toBeTruthy()
+    expect(isChanged({}, {})).toBeTruthy()
+    expect(isChanged({ a: 'a' }, {})).toBeTruthy()
+    expect(isChanged({ a: 'a' }, { a: 'b' })).toBeFalsy()
+    expect(isChanged({ a: 'a' }, { b: 'a' })).toBeFalsy()
+    expect(isChanged({ a: { b: 'b' } }, { a: { b: 'a' } })).toBeTruthy()
+    expect(isChanged({ a: [{ b: 'b' }] }, { a: [{ b: 'a' }] })).toBeTruthy()
+  })
+})
 
 describe('convertCurrency', () => {
   test('should convert currency values to float from form object', async () => {

--- a/spec/javascript/utils/utils.test.js
+++ b/spec/javascript/utils/utils.test.js
@@ -30,7 +30,6 @@ describe('isChanged', () => {
   test('should return false when both objects are equal', () => {
     expect(isChanged(undefined, undefined)).toBeFalsy()
     expect(isChanged(null, null)).toBeFalsy()
-    expect(isChanged(null, undefined)).toBeFalsy()
     expect(isChanged({}, {})).toBeFalsy()
     expect(isChanged({ a: 'a' }, { a: 'a' })).toBeFalsy()
     expect(isChanged({ a: { b: 'b' } }, { a: { b: 'b' } })).toBeFalsy()
@@ -38,12 +37,12 @@ describe('isChanged', () => {
   })
 
   test('should return true when both objects are unequal', () => {
+    expect(isChanged(null, undefined)).toBeTruthy()
     expect(isChanged(undefined, {})).toBeTruthy()
     expect(isChanged(null, {})).toBeTruthy()
-    expect(isChanged({}, {})).toBeTruthy()
     expect(isChanged({ a: 'a' }, {})).toBeTruthy()
-    expect(isChanged({ a: 'a' }, { a: 'b' })).toBeFalsy()
-    expect(isChanged({ a: 'a' }, { b: 'a' })).toBeFalsy()
+    expect(isChanged({ a: 'a' }, { a: 'b' })).toBeTruthy()
+    expect(isChanged({ a: 'a' }, { b: 'a' })).toBeTruthy()
     expect(isChanged({ a: { b: 'b' } }, { a: { b: 'a' } })).toBeTruthy()
     expect(isChanged({ a: [{ b: 'b' }] }, { a: [{ b: 'a' }] })).toBeTruthy()
   })


### PR DESCRIPTION
[DAH-93]

This change:
- hooks up the save button in the lease section to save just the lease and assistances
- Changes the behavior of the top-level save button to only save the lease and assistances when the user is in edit mode
- changes the behavior of the lease, assistances and application actions to only trigger an api call if something has changed.
- Updates the tests to no longer put expects in .then(). Errors were going unnoticed because if you throw in a then it still marks the test as passing for some reason!
 


[DAH-93]: https://sfgovdt.jira.com/browse/DAH-93