### PR TITLE
Validate lease and rental assistances on save [DAH-93]

### DIFF
--- a/app/javascript/components/supplemental_application/SupplementalApplicationContainer.js
+++ b/app/javascript/components/supplemental_application/SupplementalApplicationContainer.js
@@ -70,7 +70,7 @@ const Income = ({ listingAmiCharts, visited, form }) => (
   </ContentSection>
 )
 
-const LeaseSection = ({ form, submitting, values, onCreateLeaseClick, showLeaseSection }) => (
+const LeaseSection = ({ form, values, onCreateLeaseClick, showLeaseSection }) => (
   <ContentSection
     title='Lease'
     description={!showLeaseSection && 'Complete this section when a unit is chosen and the lease is signed. If the household receives recurring rental assistance, remember to subtract this from the unit’s rent when calculating Tenant Contribution.'}
@@ -79,7 +79,6 @@ const LeaseSection = ({ form, submitting, values, onCreateLeaseClick, showLeaseS
       <Lease
         form={form}
         values={values}
-        submitting={submitting}
       />
     ) : <Button id='create-lease' text='Create Lease' small onClick={onCreateLeaseClick} />
     }
@@ -182,7 +181,6 @@ const SupplementalApplicationContainer = ({ store }) => {
         handleSubmit,
         form,
         touched,
-        submitting,
         values,
         visited
       }) => (
@@ -221,7 +219,6 @@ const SupplementalApplicationContainer = ({ store }) => {
                   <LeaseSection
                     form={form}
                     values={values}
-                    submitting={submitting}
                     showLeaseSection={leaseSectionState !== NO_LEASE_STATE}
                     onCreateLeaseClick={handleCreateLeaseClick}
                   />

--- a/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
+++ b/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
@@ -451,11 +451,7 @@ const mapProperties = ({
     application: setApplicationsDefaults(application),
     listing: application.listing,
     statusHistory: statusHistory,
-    onSubmit: (values) => updateApplication(
-      values,
-      application,
-      shouldSaveLeaseOnApplicationSave(leaseSectionState)
-    ),
+    onSubmit: (values) => this.handleSaveApplication(values),
     fileBaseUrl: fileBaseUrl,
     units: units,
     availableUnits: availableUnits

--- a/app/javascript/components/supplemental_application/sections/Lease.js
+++ b/app/javascript/components/supplemental_application/sections/Lease.js
@@ -83,7 +83,7 @@ const LeaseActions = ({
   )
 }
 
-const Lease = ({ form, submitting, values, store }) => {
+const Lease = ({ form, values, store }) => {
   const {
     availableUnits,
     application,
@@ -174,7 +174,6 @@ const Lease = ({ form, submitting, values, store }) => {
         </FormGrid.Row>
         <RentalAssistance
           form={form}
-          submitting={submitting}
           disabled={disabled}
           loading={loading}
         />

--- a/app/javascript/components/supplemental_application/sections/Lease.js
+++ b/app/javascript/components/supplemental_application/sections/Lease.js
@@ -17,6 +17,7 @@ import { MultiDateField } from '~/utils/form/final_form/MultiDateField'
 import { validateLeaseCurrency } from '~/utils/form/validations'
 import { EDIT_LEASE_STATE } from '../SupplementalApplicationPage'
 import { doesApplicationHaveLease } from '~/utils/leaseUtils'
+import { areLeaseAndRentalAssistancesValid } from '~/utils/form/formSectionValidations'
 
 const toggleNoPreferenceUsed = (form, event) => {
   // lease.preference_used need to be reset, otherwise SF validation fails
@@ -119,6 +120,15 @@ const Lease = ({ form, submitting, values, store }) => {
 
   const areNoUnitsAvailable = !availableUnitsOptions.length
 
+  const validateAndSaveLease = (form) => {
+    if (areLeaseAndRentalAssistancesValid(form)) {
+      handleSaveLease(convertPercentAndCurrency(form.getState().values))
+    } else {
+      // submit to force errors to display
+      form.submit()
+    }
+  }
+
   return (
     <InlineModal>
       <ContentSection.Header description='If the household receives recurring rental assistance, remember to subtract this from the unit’s rent when calculating Tenant Contribution.' />
@@ -206,9 +216,8 @@ const Lease = ({ form, submitting, values, store }) => {
         </FormGrid.Row>
       </ContentSection.Sub>
       <FormGrid.Row>
-        {/* TODO: Wire up actions for buttons, set to disabled when loading */}
         <LeaseActions
-          onSave={() => handleSaveLease(convertPercentAndCurrency(form.getState().values))}
+          onSave={() => validateAndSaveLease(form)}
           onCancelLeaseClick={() => handleCancelLeaseClick(form)}
           onEditLeaseClick={handleEditLeaseClick}
           onDelete={handleDeleteLease}

--- a/app/javascript/components/supplemental_application/sections/RentalAssistance.js
+++ b/app/javascript/components/supplemental_application/sections/RentalAssistance.js
@@ -47,7 +47,6 @@ const isOther = (values) => values && values.type_of_assistance === 'Other'
 
 export const RentalAssistanceTable = ({
   form,
-  submitting,
   rentalAssistances,
   onCancelEdit,
   onSave,
@@ -124,7 +123,7 @@ export const RentalAssistanceTable = ({
         rows={rows}
         expanderRenderer={expanderRenderer}
         expandedRowRenderer={expandedRowRenderer(rentalAssistances, form)}
-        closeAllRows={submitting || disabled}
+        closeAllRows={disabled}
         classes={['rental-assistances']}
       />
     </TableWrapper>
@@ -269,7 +268,6 @@ export const RentalAssistanceForm = ({
 const RentalAssistance = ({
   store,
   form,
-  submitting,
   visited,
   disabled
 }) => {
@@ -331,7 +329,6 @@ const RentalAssistance = ({
           onSave={handleSave}
           form={form}
           loading={loading}
-          submitting={submitting}
           disabled={disabled}
         />
       )}

--- a/app/javascript/components/supplemental_application/sections/RentalAssistance.js
+++ b/app/javascript/components/supplemental_application/sections/RentalAssistance.js
@@ -9,6 +9,7 @@ import FormGrid from '~/components/molecules/FormGrid'
 import InlineModal from '~/components/molecules/InlineModal'
 import formUtils from '~/utils/formUtils'
 import validate, { convertCurrency } from '~/utils/form/validations'
+import { isSingleRentalAssistanceValid } from '~/utils/form/formSectionValidations'
 import {
   CurrencyField,
   HelpText,
@@ -162,7 +163,7 @@ export const RentalAssistanceForm = ({
   }
 
   const isFormValid = () => {
-    const isValid = isEmpty(form.getState().errors.rental_assistances) || isEmpty(form.getState().errors.rental_assistances[index])
+    const isValid = isSingleRentalAssistanceValid(form, index)
     if (!isValid) {
       // Force submit to show errors on forms
       form.submit()

--- a/app/javascript/utils/form/formSectionValidations.js
+++ b/app/javascript/utils/form/formSectionValidations.js
@@ -7,7 +7,7 @@ export const isSingleRentalAssistanceValid = (form, rentalAssistanceIndex) => {
 
 export const areAllRentalAssistancesValid = (form) => {
   const assistanceErrors = form.getState().errors.rental_assistances
-  return assistanceErrors.every(isEmpty)
+  return isEmpty(assistanceErrors) || assistanceErrors.every(isEmpty)
 }
 
 export const areLeaseAndRentalAssistancesValid = (form) => {

--- a/app/javascript/utils/form/formSectionValidations.js
+++ b/app/javascript/utils/form/formSectionValidations.js
@@ -1,0 +1,16 @@
+import { isEmpty } from 'lodash'
+
+export const isSingleRentalAssistanceValid = (form, rentalAssistanceIndex) => {
+  const assistanceErrors = form.getState().errors.rental_assistances
+  return isEmpty(assistanceErrors) || isEmpty(assistanceErrors[rentalAssistanceIndex])
+}
+
+export const areAllRentalAssistancesValid = (form) => {
+  const assistanceErrors = form.getState().errors.rental_assistances
+  return assistanceErrors.every(isEmpty)
+}
+
+export const areLeaseAndRentalAssistancesValid = (form) => {
+  const leaseErrors = form.getState().errors.lease
+  return isEmpty(leaseErrors) && areAllRentalAssistancesValid(form)
+}

--- a/spec/javascript/components/supplemental_application/sections/RentalAssistance.test.js
+++ b/spec/javascript/components/supplemental_application/sections/RentalAssistance.test.js
@@ -85,7 +85,7 @@ describe('RentalAssistance', () => {
 })
 
 describe('RentalAssistanceTable', () => {
-  const getWrapper = ({ submitting = false, disabled = false }) => {
+  const getWrapper = ({ disabled = false }) => {
     const context = cloneDeep(baseContext)
     context.application.rental_assistances = [rentalAssistance]
 
@@ -96,7 +96,6 @@ describe('RentalAssistanceTable', () => {
           form={form}
           rentalAssistances={[rentalAssistance]}
           applicationMembers={[]}
-          submitting={submitting}
           disabled={disabled}
         />
       )
@@ -108,23 +107,13 @@ describe('RentalAssistanceTable', () => {
     expect(wrapper.find(ExpandableTable)).toHaveLength(1)
   })
 
-  test('should not close all panels if not submitting or disabled', () => {
+  test('should not close all panels if not disabled', () => {
     const wrapper = getWrapper({})
     expect(wrapper.find(ExpandableTable).prop('closeAllRows')).toBeFalsy()
   })
 
-  test('should close all panels when submitting', () => {
-    const wrapper = getWrapper({ submitting: true })
-    expect(wrapper.find(ExpandableTable).prop('closeAllRows')).toBeTruthy()
-  })
-
   test('should close all panels when disabled', () => {
     const wrapper = getWrapper({ disabled: true })
-    expect(wrapper.find(ExpandableTable).prop('closeAllRows')).toBeTruthy()
-  })
-
-  test('should close all panels when submitting and disabled', () => {
-    const wrapper = getWrapper({ disabled: true, submitting: true })
     expect(wrapper.find(ExpandableTable).prop('closeAllRows')).toBeTruthy()
   })
 })

--- a/spec/javascript/utils/form/formSectionValidations.test.js
+++ b/spec/javascript/utils/form/formSectionValidations.test.js
@@ -1,0 +1,182 @@
+import {
+  isSingleRentalAssistanceValid,
+  areAllRentalAssistancesValid,
+  areLeaseAndRentalAssistancesValid
+} from 'utils/form/formSectionValidations'
+
+const ERROR = {
+  message: 'error message'
+}
+
+const NO_ERROR = {}
+
+const mockFormErrors = ({ assistanceErrors, leaseErrors }) => ({
+  getState: () => ({
+    errors: {
+      rental_assistances: assistanceErrors,
+      lease: leaseErrors
+    }
+  })
+})
+
+const mockFormWithAssistanceErrors = (errors) => mockFormErrors({ assistanceErrors: errors })
+
+describe('isSingleRentalAssistanceValid', () => {
+  test('should return true when rental assistance errors are null', () => {
+    const form = mockFormWithAssistanceErrors(undefined)
+    expect(isSingleRentalAssistanceValid(form, 0)).toBeTruthy()
+  })
+
+  test('should return true when rental assistance errors are empty', () => {
+    const form = mockFormWithAssistanceErrors([])
+    expect(isSingleRentalAssistanceValid(form, 0)).toBeTruthy()
+  })
+
+  test('should return true when the assistance at that index is empty', () => {
+    const form = mockFormWithAssistanceErrors([NO_ERROR, ERROR])
+    expect(isSingleRentalAssistanceValid(form, 0)).toBeTruthy()
+  })
+
+  test('should return false when the assistance at that index is not empty', () => {
+    const form = mockFormWithAssistanceErrors([NO_ERROR, ERROR])
+    expect(isSingleRentalAssistanceValid(form, 1)).toBeFalsy()
+  })
+})
+
+describe('areAllRentalAssistancesValid', () => {
+  test('should return true when rental assistance errors are null', () => {
+    const form = mockFormWithAssistanceErrors(undefined)
+    expect(areAllRentalAssistancesValid(form)).toBeTruthy()
+  })
+
+  test('should return true when rental assistance errors are empty', () => {
+    const form = mockFormWithAssistanceErrors([])
+    expect(areAllRentalAssistancesValid(form)).toBeTruthy()
+  })
+
+  test('should return true with a single valid assistance', () => {
+    const form = mockFormWithAssistanceErrors([NO_ERROR])
+    expect(areAllRentalAssistancesValid(form)).toBeTruthy()
+  })
+
+  test('should return true with multiple valid assistances', () => {
+    const form = mockFormWithAssistanceErrors([NO_ERROR, NO_ERROR])
+    expect(areAllRentalAssistancesValid(form)).toBeTruthy()
+  })
+
+  test('should return false with a single invalid assistance', () => {
+    const form = mockFormWithAssistanceErrors([ERROR])
+    expect(areAllRentalAssistancesValid(form)).toBeFalsy()
+  })
+
+  test('should return false with multiple invalid assistance', () => {
+    const form = mockFormWithAssistanceErrors([ERROR, ERROR])
+    expect(areAllRentalAssistancesValid(form)).toBeFalsy()
+  })
+
+  test('should return false with a mix of valid and invalid assistances', () => {
+    let form = mockFormWithAssistanceErrors([NO_ERROR, NO_ERROR, ERROR])
+    expect(areAllRentalAssistancesValid(form)).toBeFalsy()
+
+    form = mockFormWithAssistanceErrors([ERROR, NO_ERROR, NO_ERROR])
+    expect(areAllRentalAssistancesValid(form)).toBeFalsy()
+  })
+})
+
+describe('areLeaseAndRentalAssistancesValid', () => {
+  const getResult = (assistanceErrors, leaseErrors) => {
+    const form = mockFormErrors({
+      assistanceErrors: assistanceErrors,
+      leaseErrors: leaseErrors
+    })
+
+    return areLeaseAndRentalAssistancesValid(form)
+  }
+  describe('with undefined rental assistances', () => {
+    const assistanceErrors = undefined
+
+    test('should return true when lease errors are undefined', () => {
+      const leaseErrors = undefined
+      const result = getResult(assistanceErrors, leaseErrors)
+      expect(result).toBeTruthy()
+    })
+
+    test('should return true when lease has no errors', () => {
+      const leaseErrors = NO_ERROR
+      const result = getResult(assistanceErrors, leaseErrors)
+      expect(result).toBeTruthy()
+    })
+
+    test('should return false when lease has errors', () => {
+      const leaseErrors = ERROR
+      const result = getResult(assistanceErrors, leaseErrors)
+      expect(result).toBeFalsy()
+    })
+  })
+
+  describe('with empty rental assistances', () => {
+    const assistanceErrors = []
+
+    test('should return true when lease errors are undefined', () => {
+      const leaseErrors = undefined
+      const result = getResult(assistanceErrors, leaseErrors)
+      expect(result).toBeTruthy()
+    })
+
+    test('should return true when lease has no errors', () => {
+      const leaseErrors = NO_ERROR
+      const result = getResult(assistanceErrors, leaseErrors)
+      expect(result).toBeTruthy()
+    })
+
+    test('should return false when lease has errors', () => {
+      const leaseErrors = ERROR
+      const result = getResult(assistanceErrors, leaseErrors)
+      expect(result).toBeFalsy()
+    })
+  })
+
+  describe('with valid rental assistances', () => {
+    const assistanceErrors = [NO_ERROR, NO_ERROR, NO_ERROR]
+
+    test('should return true when lease errors are undefined', () => {
+      const leaseErrors = undefined
+      const result = getResult(assistanceErrors, leaseErrors)
+      expect(result).toBeTruthy()
+    })
+
+    test('should return true when lease has no errors', () => {
+      const leaseErrors = NO_ERROR
+      const result = getResult(assistanceErrors, leaseErrors)
+      expect(result).toBeTruthy()
+    })
+
+    test('should return false when lease has errors', () => {
+      const leaseErrors = ERROR
+      const result = getResult(assistanceErrors, leaseErrors)
+      expect(result).toBeFalsy()
+    })
+  })
+
+  describe('with invalid rental assistances', () => {
+    const assistanceErrors = [ERROR, ERROR, NO_ERROR]
+
+    test('should return false when lease errors are undefined', () => {
+      const leaseErrors = undefined
+      const result = getResult(assistanceErrors, leaseErrors)
+      expect(result).toBeFalsy()
+    })
+
+    test('should return false when lease has no errors', () => {
+      const leaseErrors = NO_ERROR
+      const result = getResult(assistanceErrors, leaseErrors)
+      expect(result).toBeFalsy()
+    })
+
+    test('should return false when lease has errors', () => {
+      const leaseErrors = ERROR
+      const result = getResult(assistanceErrors, leaseErrors)
+      expect(result).toBeFalsy()
+    })
+  })
+})


### PR DESCRIPTION
This adds lease and rental assistance validation on lease save.

I think opening the rental assistance panel on error is going to be difficult and probably not worth the work, but we can open a ticket to add it later. Especially now that rental assistances are properly validated it shouldn't be possible to save an assistance without a type


![save lease validation](https://user-images.githubusercontent.com/64036574/93150419-e92c6f80-f6ad-11ea-820f-dd9a1949a422.gif)
