### PR TITLE
Add jsconfig.json for vscode path completion

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./app/javascript/*"],
+    }
+  },
+}


### PR DESCRIPTION
Vscode has trouble navigating to definitions when we use paths from an aliased home directory, like 
```
import { doesApplicationHaveLease } from '~/utils/leaseUtils'
```

With this new jsconfig.json file, vscode can resolve these references so you can easily jump to function or component definitions.