### PR TITLE
Add Delete confirmation modal [DAH-123]

### DIFF
--- a/app/javascript/components/organisms/ConfirmationModal.js
+++ b/app/javascript/components/organisms/ConfirmationModal.js
@@ -1,0 +1,68 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import classNames from 'classnames'
+
+import Modal from './Modal'
+
+const ConfirmationModal = ({
+  isOpen = false,
+  onCloseClick = () => {},
+  onPrimaryClick = () => {},
+  onSecondaryClick = () => {},
+  primaryText,
+  primaryButtonDestination = null,
+  primaryButtonIsAlert = false,
+  secondaryText,
+  subtitle,
+  title,
+  titleId = 'confirmation-modal-header'
+}) => {
+  const buttonClasses = classNames(
+    'button',
+    primaryButtonIsAlert ? 'alert' : 'primary'
+  )
+
+  return (
+    <Modal isOpen={isOpen} handleClose={onCloseClick}>
+      <Modal.Body hidden={isOpen} handleClose={onCloseClick}>
+        <Modal.Header id={titleId} title={title} />
+        <Modal.Content>
+          <p>{subtitle}</p>
+        </Modal.Content>
+        <Modal.Footer>
+          <div className='modal-button_item modal-button_secondary'>
+            <a
+              className={buttonClasses}
+              href={primaryButtonDestination || '#'}
+              type='button'
+              onClick={onPrimaryClick}
+            >
+              {primaryText}
+            </a>
+          </div>
+          <div className='modal-button_item modal-button_secondary'>
+            <button className='button no-border' onClick={onSecondaryClick} type='button'>
+              {secondaryText}
+            </button>
+          </div>
+        </Modal.Footer>
+      </Modal.Body>
+    </Modal>
+  )
+}
+
+ConfirmationModal.propTypes = {
+  isOpen: PropTypes.bool,
+  onCloseClick: PropTypes.func,
+  onPrimaryClick: PropTypes.func,
+  onSecondaryClick: PropTypes.func,
+  primaryButtonDestination: PropTypes.string,
+  primaryButtonIsAlert: PropTypes.bool,
+  primaryText: PropTypes.string,
+  secondaryText: PropTypes.string,
+  subtitle: PropTypes.string,
+  title: PropTypes.string,
+  titleId: PropTypes.string
+}
+
+export default ConfirmationModal

--- a/app/javascript/components/organisms/LeaveConfirmationModal.js
+++ b/app/javascript/components/organisms/LeaveConfirmationModal.js
@@ -1,24 +1,20 @@
 import React from 'react'
 
-import Modal from './Modal'
+import ConfirmationModal from './ConfirmationModal'
 
 const LeaveConfirmationModal = ({ isOpen, handleClose, destination }) => (
-  <Modal isOpen={isOpen} handleClose={handleClose}>
-    <Modal.Body hidden={isOpen} handleClose={handleClose}>
-      <Modal.Header id={'leave-confirmation-modal'} title={'Are you sure you want to leave this page?'} />
-      <Modal.Content>
-        <p>You will lose your unsaved changes.</p>
-      </Modal.Content>
-      <Modal.Footer>
-        <div className='modal-button_item modal-button_primary'>
-          <a className='button alert' href={destination}>Discard Changes</a>
-        </div>
-        <div className='modal-button_item modal-button_secondary'>
-          <button className='button no-border' onClick={handleClose} type='button'>Keep Editing</button>
-        </div>
-      </Modal.Footer>
-    </Modal.Body>
-  </Modal>
+  <ConfirmationModal
+    isOpen={isOpen}
+    onCloseClick={handleClose}
+    onSecondaryClick={handleClose}
+    primaryButtonIsAlert
+    primaryButtonDestination={destination}
+    primaryText='Discard Changes'
+    secondaryText='Keep Editing'
+    subtitle='You will lose your unsaved changes.'
+    title='Are you sure you want to leave this page?'
+    titleId='leave-confirmation-modal'
+  />
 )
 
 export default LeaveConfirmationModal

--- a/app/javascript/components/supplemental_application/sections/Lease.js
+++ b/app/javascript/components/supplemental_application/sections/Lease.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { filter, map, isEmpty } from 'lodash'
 
 import Button from '~/components/atoms/Button'
@@ -9,6 +9,7 @@ import formUtils from '~/utils/formUtils'
 import ParkingInformationInputs from './ParkingInformationInputs'
 import RentalAssistance from './RentalAssistance'
 import { convertPercentAndCurrency } from '../../../utils/form/validations'
+import ConfirmationModal from '~/components/organisms/ConfirmationModal'
 
 import { pluck } from '~/utils/utils'
 import { withContext } from '../context'
@@ -94,6 +95,8 @@ const Lease = ({ form, submitting, values, store }) => {
     loading
   } = store
 
+  const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false)
+
   const isEditingMode = leaseSectionState === EDIT_LEASE_STATE
   const disabled = !isEditingMode
 
@@ -116,6 +119,14 @@ const Lease = ({ form, submitting, values, store }) => {
   const getVisited = (fieldName) => (
     form.getFieldState(fieldName)?.visited
   )
+
+  const openDeleteLeaseConfirmation = () => setShowDeleteConfirmation(true)
+  const closeDeleteLeaseConfirmation = () => setShowDeleteConfirmation(false)
+
+  const handleDeleteLeaseConfirmed = () => {
+    setShowDeleteConfirmation(false)
+    handleDeleteLease()
+  }
 
   const areNoUnitsAvailable = !availableUnitsOptions.length
 
@@ -211,12 +222,23 @@ const Lease = ({ form, submitting, values, store }) => {
           onSave={() => handleSaveLease(convertPercentAndCurrency(form.getState().values))}
           onCancelLeaseClick={() => handleCancelLeaseClick(form)}
           onEditLeaseClick={handleEditLeaseClick}
-          onDelete={handleDeleteLease}
+          onDelete={openDeleteLeaseConfirmation}
           loading={loading}
           leaseExists={doesApplicationHaveLease(application)}
           isEditing={isEditingMode}
         />
       </FormGrid.Row>
+      <ConfirmationModal
+        isOpen={showDeleteConfirmation}
+        onCloseClick={closeDeleteLeaseConfirmation}
+        onSecondaryClick={closeDeleteLeaseConfirmation}
+        onPrimaryClick={handleDeleteLeaseConfirmed}
+        primaryButtonIsAlert
+        primaryText='Delete Lease'
+        secondaryText='Continue Editing'
+        subtitle='This will permanently delete the lease and all related rental assistances.'
+        title='Are you sure you want to delete this lease?'
+      />
     </InlineModal>
   )
 }

--- a/spec/javascript/components/organisms/ConfirmationModal.test.js
+++ b/spec/javascript/components/organisms/ConfirmationModal.test.js
@@ -1,0 +1,144 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import ConfirmationModal from '~/components/organisms/ConfirmationModal'
+import Modal from '~/components/organisms/Modal'
+
+import { findWithText } from '../../testUtils/wrapperUtil'
+
+const PRIMARY_TEXT = 'Primary Text'
+const SECONDARY_TEXT = 'Secondary Text'
+const TITLE = 'Title'
+const SUBTITLE = 'Subtitle'
+
+const ON_CLOSE = jest.fn()
+const ON_PRIMARY_CLICK = jest.fn()
+const ON_SECONDARY_CLICK = jest.fn()
+
+const getWrapper = (propOverrides = {}) => shallow(
+  <ConfirmationModal
+    onPrimaryClick={ON_PRIMARY_CLICK}
+    onSecondaryClick={ON_SECONDARY_CLICK}
+    onCloseClick={ON_CLOSE}
+    primaryText={PRIMARY_TEXT}
+    secondaryText={SECONDARY_TEXT}
+    subtitle={SUBTITLE}
+    title={TITLE}
+    {...propOverrides}
+  />
+)
+
+describe('ConfirmationModal', () => {
+  describe('with default props', () => {
+    let wrapper
+    beforeEach(() => {
+      wrapper = getWrapper()
+    })
+
+    test('should render the modal as closed', () => {
+      expect(wrapper.find(Modal).prop('isOpen')).toBeFalsy()
+      expect(wrapper.find(Modal.Body).prop('hidden')).toBeFalsy()
+    })
+
+    test('should render the title and subtitle', () => {
+      expect(wrapper.find(Modal.Header).prop('title')).toEqual(TITLE)
+      expect(wrapper.find(Modal.Content).dive().text()).toEqual(SUBTITLE)
+    })
+
+    test('should render with the default header id', () => {
+      expect(wrapper.find(Modal.Header).prop('id')).toEqual('confirmation-modal-header')
+    })
+
+    test('should render the primary button as a link with href=#', () => {
+      const primaryButtonWrapper = findWithText(wrapper, 'a', PRIMARY_TEXT)
+      expect(primaryButtonWrapper).toHaveLength(1)
+      expect(primaryButtonWrapper.prop('href')).toEqual('#')
+    })
+
+    test('should render the primary button with primary style', () => {
+      const primaryWrapper = findWithText(wrapper, 'a', PRIMARY_TEXT)
+      expect(primaryWrapper.prop('className').includes('primary')).toBeTruthy()
+    })
+
+    test('should render the secondary button', () => {
+      expect(findWithText(wrapper, 'button', SECONDARY_TEXT)).toHaveLength(1)
+    })
+
+    test('should render the secondary button', () => {
+      expect(findWithText(wrapper, 'button', SECONDARY_TEXT)).toHaveLength(1)
+    })
+
+    test('should trigger the onClose listener when close is clicked', () => {
+      wrapper.find(Modal).prop('handleClose')()
+
+      expect(ON_CLOSE.mock.calls.length).toEqual(1)
+      expect(ON_PRIMARY_CLICK.mock.calls.length).toEqual(0)
+      expect(ON_SECONDARY_CLICK.mock.calls.length).toEqual(0)
+    })
+
+    test('should trigger the onPrimaryClick listener when primary button is clicked', () => {
+      findWithText(wrapper, 'a', PRIMARY_TEXT).simulate('click')
+
+      expect(ON_CLOSE.mock.calls.length).toEqual(0)
+      expect(ON_PRIMARY_CLICK.mock.calls.length).toEqual(1)
+      expect(ON_SECONDARY_CLICK.mock.calls.length).toEqual(0)
+    })
+
+    test('should trigger the onSecondaryClick listener when secondary button is clicked', () => {
+      findWithText(wrapper, 'button', SECONDARY_TEXT).simulate('click')
+
+      expect(ON_CLOSE.mock.calls.length).toEqual(0)
+      expect(ON_PRIMARY_CLICK.mock.calls.length).toEqual(0)
+      expect(ON_SECONDARY_CLICK.mock.calls.length).toEqual(1)
+    })
+  })
+
+  describe('with custom titleId', () => {
+    const CUSTOM_TITLE_ID = 'custom-title-id'
+    let wrapper
+    beforeEach(() => {
+      wrapper = getWrapper({ titleId: CUSTOM_TITLE_ID })
+    })
+
+    test('should render with the custom header id', () => {
+      expect(wrapper.find(Modal.Header).prop('id')).toEqual(CUSTOM_TITLE_ID)
+    })
+  })
+
+  describe('when isOpen is true', () => {
+    let wrapper
+    beforeEach(() => {
+      wrapper = getWrapper({ isOpen: true })
+    })
+
+    test('should render the modal as open', () => {
+      expect(wrapper.find(Modal).prop('isOpen')).toBeTruthy()
+      expect(wrapper.find(Modal.Body).prop('hidden')).toBeTruthy()
+    })
+  })
+
+  describe('when primaryButtonIsAlert is true', () => {
+    let wrapper
+    beforeEach(() => {
+      wrapper = getWrapper({ primaryButtonIsAlert: true })
+    })
+
+    test('should render the primary button with alert styling', () => {
+      const primaryWrapper = findWithText(wrapper, 'a', PRIMARY_TEXT)
+      expect(primaryWrapper.prop('className').includes('alert')).toBeTruthy()
+    })
+  })
+
+  describe('when primaryButtonDestination is provided', () => {
+    const DESTINATION = '/destinationPath'
+    let wrapper
+    beforeEach(() => {
+      wrapper = getWrapper({ primaryButtonDestination: DESTINATION })
+    })
+
+    test('should render the primary button with the correct href', () => {
+      const primaryWrapper = findWithText(wrapper, 'a', PRIMARY_TEXT)
+      expect(primaryWrapper.prop('href')).toEqual(DESTINATION)
+    })
+  })
+})

--- a/spec/javascript/components/organisms/__snapshots__/LeaveConfirmationModal.test.js.snap
+++ b/spec/javascript/components/organisms/__snapshots__/LeaveConfirmationModal.test.js.snap
@@ -6,298 +6,117 @@ exports[`LeaveConfirmationModal it should render successfully 1`] = `
   handleClose={[MockFunction]}
   isOpen={true}
 >
-  <Modal
-    handleClose={[MockFunction]}
+  <ConfirmationModal
     isOpen={true}
+    onCloseClick={[MockFunction]}
+    onSecondaryClick={[MockFunction]}
+    primaryButtonDestination="/applications/asdf1234"
+    primaryButtonIsAlert={true}
+    primaryText="Discard Changes"
+    secondaryText="Keep Editing"
+    subtitle="You will lose your unsaved changes."
+    title="Are you sure you want to leave this page?"
+    titleId="leave-confirmation-modal"
   >
     <Modal
-      ariaHideApp={false}
-      bodyOpenClassName="ReactModal__Body--open"
-      closeTimeoutMS={0}
+      handleClose={[MockFunction]}
       isOpen={true}
-      onRequestClose={[MockFunction]}
-      parentSelector={[Function]}
-      portalClassName="ReactModalPortal"
-      role="dialog"
-      shouldCloseOnEsc={true}
-      shouldCloseOnOverlayClick={true}
-      shouldFocusAfterRender={true}
-      shouldReturnFocusAfterClose={true}
-      style={
-        Object {
-          "content": Object {
-            "border": "0",
-            "borderRadius": "4px",
-            "bottom": "auto",
-            "left": "50%",
-            "minHeight": "10rem",
-            "opacity": "1",
-            "overflow": "visible",
-            "padding": "0px",
-            "position": "fixed",
-            "right": "auto",
-            "top": "50%",
-            "transform": "translate(-50%,-50%)",
-            "width": "600px",
-          },
-          "overlay": Object {
-            "backgroundColor": "rgba(0,0,0,0.3)",
-          },
-        }
-      }
     >
-      <Portal
-        containerInfo={
-          <div
-            class="ReactModalPortal"
-          >
-            <div
-              class="ReactModal__Overlay ReactModal__Overlay--after-open"
-              style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(0, 0, 0, 0.3);"
-            >
-              <div
-                class="ReactModal__Content ReactModal__Content--after-open"
-                role="dialog"
-                style="position: fixed; top: 50%; left: 50%; border: 0px; background: rgb(255, 255, 255); overflow: visible; border-radius: 4px; outline: none; padding: 0px; opacity: 1; min-height: 10rem; transform: translate(-50%,-50%); width: 600px;"
-                tabindex="-1"
-              >
-                <div
-                  aria-hidden="true"
-                  aria-labelledby="modalTitle"
-                  role="dialog"
-                >
-                  <header
-                    class="modal-inner margin-top"
-                    id="leave-confirmation-modal"
-                  >
-                    <h1
-                      class="modal-title t-gamma no-margin"
-                    >
-                      Are you sure you want to leave this page?
-                    </h1>
-                  </header>
-                  <section
-                    class="modal-inner"
-                  >
-                    <p>
-                      You will lose your unsaved changes.
-                    </p>
-                  </section>
-                  <footer
-                    class="modal-footer bg-dust"
-                  >
-                    <div
-                      class="modal-button-group row"
-                    >
-                      <div
-                        class="modal-button_item modal-button_primary"
-                      >
-                        <a
-                          class="button alert"
-                          href="/applications/asdf1234"
-                        >
-                          Discard Changes
-                        </a>
-                      </div>
-                      <div
-                        class="modal-button_item modal-button_secondary"
-                      >
-                        <button
-                          class="button no-border"
-                          type="button"
-                        >
-                          Keep Editing
-                        </button>
-                      </div>
-                    </div>
-                  </footer>
-                  <button
-                    aria-label="Close modal"
-                    class="button button-link close-reveal-modal"
-                  >
-                    <span
-                      class="sr-only"
-                    >
-                      Close
-                    </span>
-                    <span
-                      class="ui-icon ui-medium i-primary"
-                    >
-                      <svg>
-                        <use
-                          xlink:href="#i-close"
-                        />
-                      </svg>
-                    </span>
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
+      <Modal
+        ariaHideApp={false}
+        bodyOpenClassName="ReactModal__Body--open"
+        closeTimeoutMS={0}
+        isOpen={true}
+        onRequestClose={[MockFunction]}
+        parentSelector={[Function]}
+        portalClassName="ReactModalPortal"
+        role="dialog"
+        shouldCloseOnEsc={true}
+        shouldCloseOnOverlayClick={true}
+        shouldFocusAfterRender={true}
+        shouldReturnFocusAfterClose={true}
+        style={
+          Object {
+            "content": Object {
+              "border": "0",
+              "borderRadius": "4px",
+              "bottom": "auto",
+              "left": "50%",
+              "minHeight": "10rem",
+              "opacity": "1",
+              "overflow": "visible",
+              "padding": "0px",
+              "position": "fixed",
+              "right": "auto",
+              "top": "50%",
+              "transform": "translate(-50%,-50%)",
+              "width": "600px",
+            },
+            "overlay": Object {
+              "backgroundColor": "rgba(0,0,0,0.3)",
+            },
+          }
         }
       >
-        <ModalPortal
-          ariaHideApp={false}
-          bodyOpenClassName="ReactModal__Body--open"
-          closeTimeoutMS={0}
-          defaultStyles={
-            Object {
-              "content": Object {
-                "WebkitOverflowScrolling": "touch",
-                "background": "#fff",
-                "border": "1px solid #ccc",
-                "borderRadius": "4px",
-                "bottom": "40px",
-                "left": "40px",
-                "outline": "none",
-                "overflow": "auto",
-                "padding": "20px",
-                "position": "absolute",
-                "right": "40px",
-                "top": "40px",
-              },
-              "overlay": Object {
-                "backgroundColor": "rgba(255, 255, 255, 0.75)",
-                "bottom": 0,
-                "left": 0,
-                "position": "fixed",
-                "right": 0,
-                "top": 0,
-              },
-            }
-          }
-          isOpen={true}
-          onRequestClose={[MockFunction]}
-          parentSelector={[Function]}
-          portalClassName="ReactModalPortal"
-          role="dialog"
-          shouldCloseOnEsc={true}
-          shouldCloseOnOverlayClick={true}
-          shouldFocusAfterRender={true}
-          shouldReturnFocusAfterClose={true}
-          style={
-            Object {
-              "content": Object {
-                "border": "0",
-                "borderRadius": "4px",
-                "bottom": "auto",
-                "left": "50%",
-                "minHeight": "10rem",
-                "opacity": "1",
-                "overflow": "visible",
-                "padding": "0px",
-                "position": "fixed",
-                "right": "auto",
-                "top": "50%",
-                "transform": "translate(-50%,-50%)",
-                "width": "600px",
-              },
-              "overlay": Object {
-                "backgroundColor": "rgba(0,0,0,0.3)",
-              },
-            }
-          }
-        >
-          <div
-            className="ReactModal__Overlay ReactModal__Overlay--after-open"
-            onClick={[Function]}
-            onMouseDown={[Function]}
-            style={
-              Object {
-                "backgroundColor": "rgba(0,0,0,0.3)",
-                "bottom": 0,
-                "left": 0,
-                "position": "fixed",
-                "right": 0,
-                "top": 0,
-              }
-            }
-          >
+        <Portal
+          containerInfo={
             <div
-              className="ReactModal__Content ReactModal__Content--after-open"
-              onClick={[Function]}
-              onKeyDown={[Function]}
-              onMouseDown={[Function]}
-              onMouseUp={[Function]}
-              role="dialog"
-              style={
-                Object {
-                  "WebkitOverflowScrolling": "touch",
-                  "background": "#fff",
-                  "border": "0",
-                  "borderRadius": "4px",
-                  "bottom": "auto",
-                  "left": "50%",
-                  "minHeight": "10rem",
-                  "opacity": "1",
-                  "outline": "none",
-                  "overflow": "visible",
-                  "padding": "0px",
-                  "position": "fixed",
-                  "right": "auto",
-                  "top": "50%",
-                  "transform": "translate(-50%,-50%)",
-                  "width": "600px",
-                }
-              }
-              tabIndex="-1"
+              class="ReactModalPortal"
             >
-              <Component
-                handleClose={[MockFunction]}
-                hidden={true}
+              <div
+                class="ReactModal__Overlay ReactModal__Overlay--after-open"
+                style="position: fixed; top: 0px; left: 0px; right: 0px; bottom: 0px; background-color: rgba(0, 0, 0, 0.3);"
               >
                 <div
-                  aria-hidden={true}
-                  aria-labelledby="modalTitle"
+                  class="ReactModal__Content ReactModal__Content--after-open"
                   role="dialog"
+                  style="position: fixed; top: 50%; left: 50%; border: 0px; background: rgb(255, 255, 255); overflow: visible; border-radius: 4px; outline: none; padding: 0px; opacity: 1; min-height: 10rem; transform: translate(-50%,-50%); width: 600px;"
+                  tabindex="-1"
                 >
-                  <Component
-                    id="leave-confirmation-modal"
-                    title="Are you sure you want to leave this page?"
+                  <div
+                    aria-hidden="true"
+                    aria-labelledby="modalTitle"
+                    role="dialog"
                   >
                     <header
-                      className="modal-inner margin-top"
+                      class="modal-inner margin-top"
                       id="leave-confirmation-modal"
                     >
                       <h1
-                        className="modal-title t-gamma no-margin"
+                        class="modal-title t-gamma no-margin"
                       >
                         Are you sure you want to leave this page?
                       </h1>
                     </header>
-                  </Component>
-                  <Component>
                     <section
-                      className="modal-inner"
+                      class="modal-inner"
                     >
                       <p>
                         You will lose your unsaved changes.
                       </p>
                     </section>
-                  </Component>
-                  <Component>
                     <footer
-                      className="modal-footer bg-dust"
+                      class="modal-footer bg-dust"
                     >
                       <div
-                        className="modal-button-group row"
+                        class="modal-button-group row"
                       >
                         <div
-                          className="modal-button_item modal-button_primary"
+                          class="modal-button_item modal-button_secondary"
                         >
                           <a
-                            className="button alert"
+                            class="button alert"
                             href="/applications/asdf1234"
+                            type="button"
                           >
                             Discard Changes
                           </a>
                         </div>
                         <div
-                          className="modal-button_item modal-button_secondary"
+                          class="modal-button_item modal-button_secondary"
                         >
                           <button
-                            className="button no-border"
-                            onClick={[MockFunction]}
+                            class="button no-border"
                             type="button"
                           >
                             Keep Editing
@@ -305,34 +124,231 @@ exports[`LeaveConfirmationModal it should render successfully 1`] = `
                         </div>
                       </div>
                     </footer>
-                  </Component>
-                  <button
-                    aria-label="Close modal"
-                    className="button button-link close-reveal-modal"
-                    onClick={[MockFunction]}
-                  >
-                    <span
-                      className="sr-only"
+                    <button
+                      aria-label="Close modal"
+                      class="button button-link close-reveal-modal"
                     >
-                      Close
-                    </span>
-                    <span
-                      className="ui-icon ui-medium i-primary"
-                    >
-                      <svg>
-                        <use
-                          xlinkHref="#i-close"
-                        />
-                      </svg>
-                    </span>
-                  </button>
+                      <span
+                        class="sr-only"
+                      >
+                        Close
+                      </span>
+                      <span
+                        class="ui-icon ui-medium i-primary"
+                      >
+                        <svg>
+                          <use
+                            xlink:href="#i-close"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                  </div>
                 </div>
-              </Component>
+              </div>
             </div>
-          </div>
-        </ModalPortal>
-      </Portal>
+          }
+        >
+          <ModalPortal
+            ariaHideApp={false}
+            bodyOpenClassName="ReactModal__Body--open"
+            closeTimeoutMS={0}
+            defaultStyles={
+              Object {
+                "content": Object {
+                  "WebkitOverflowScrolling": "touch",
+                  "background": "#fff",
+                  "border": "1px solid #ccc",
+                  "borderRadius": "4px",
+                  "bottom": "40px",
+                  "left": "40px",
+                  "outline": "none",
+                  "overflow": "auto",
+                  "padding": "20px",
+                  "position": "absolute",
+                  "right": "40px",
+                  "top": "40px",
+                },
+                "overlay": Object {
+                  "backgroundColor": "rgba(255, 255, 255, 0.75)",
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "fixed",
+                  "right": 0,
+                  "top": 0,
+                },
+              }
+            }
+            isOpen={true}
+            onRequestClose={[MockFunction]}
+            parentSelector={[Function]}
+            portalClassName="ReactModalPortal"
+            role="dialog"
+            shouldCloseOnEsc={true}
+            shouldCloseOnOverlayClick={true}
+            shouldFocusAfterRender={true}
+            shouldReturnFocusAfterClose={true}
+            style={
+              Object {
+                "content": Object {
+                  "border": "0",
+                  "borderRadius": "4px",
+                  "bottom": "auto",
+                  "left": "50%",
+                  "minHeight": "10rem",
+                  "opacity": "1",
+                  "overflow": "visible",
+                  "padding": "0px",
+                  "position": "fixed",
+                  "right": "auto",
+                  "top": "50%",
+                  "transform": "translate(-50%,-50%)",
+                  "width": "600px",
+                },
+                "overlay": Object {
+                  "backgroundColor": "rgba(0,0,0,0.3)",
+                },
+              }
+            }
+          >
+            <div
+              className="ReactModal__Overlay ReactModal__Overlay--after-open"
+              onClick={[Function]}
+              onMouseDown={[Function]}
+              style={
+                Object {
+                  "backgroundColor": "rgba(0,0,0,0.3)",
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "fixed",
+                  "right": 0,
+                  "top": 0,
+                }
+              }
+            >
+              <div
+                className="ReactModal__Content ReactModal__Content--after-open"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="dialog"
+                style={
+                  Object {
+                    "WebkitOverflowScrolling": "touch",
+                    "background": "#fff",
+                    "border": "0",
+                    "borderRadius": "4px",
+                    "bottom": "auto",
+                    "left": "50%",
+                    "minHeight": "10rem",
+                    "opacity": "1",
+                    "outline": "none",
+                    "overflow": "visible",
+                    "padding": "0px",
+                    "position": "fixed",
+                    "right": "auto",
+                    "top": "50%",
+                    "transform": "translate(-50%,-50%)",
+                    "width": "600px",
+                  }
+                }
+                tabIndex="-1"
+              >
+                <Component
+                  handleClose={[MockFunction]}
+                  hidden={true}
+                >
+                  <div
+                    aria-hidden={true}
+                    aria-labelledby="modalTitle"
+                    role="dialog"
+                  >
+                    <Component
+                      id="leave-confirmation-modal"
+                      title="Are you sure you want to leave this page?"
+                    >
+                      <header
+                        className="modal-inner margin-top"
+                        id="leave-confirmation-modal"
+                      >
+                        <h1
+                          className="modal-title t-gamma no-margin"
+                        >
+                          Are you sure you want to leave this page?
+                        </h1>
+                      </header>
+                    </Component>
+                    <Component>
+                      <section
+                        className="modal-inner"
+                      >
+                        <p>
+                          You will lose your unsaved changes.
+                        </p>
+                      </section>
+                    </Component>
+                    <Component>
+                      <footer
+                        className="modal-footer bg-dust"
+                      >
+                        <div
+                          className="modal-button-group row"
+                        >
+                          <div
+                            className="modal-button_item modal-button_secondary"
+                          >
+                            <a
+                              className="button alert"
+                              href="/applications/asdf1234"
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              Discard Changes
+                            </a>
+                          </div>
+                          <div
+                            className="modal-button_item modal-button_secondary"
+                          >
+                            <button
+                              className="button no-border"
+                              onClick={[MockFunction]}
+                              type="button"
+                            >
+                              Keep Editing
+                            </button>
+                          </div>
+                        </div>
+                      </footer>
+                    </Component>
+                    <button
+                      aria-label="Close modal"
+                      className="button button-link close-reveal-modal"
+                      onClick={[MockFunction]}
+                    >
+                      <span
+                        className="sr-only"
+                      >
+                        Close
+                      </span>
+                      <span
+                        className="ui-icon ui-medium i-primary"
+                      >
+                        <svg>
+                          <use
+                            xlinkHref="#i-close"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                  </div>
+                </Component>
+              </div>
+            </div>
+          </ModalPortal>
+        </Portal>
+      </Modal>
     </Modal>
-  </Modal>
+  </ConfirmationModal>
 </LeaveConfirmationModal>
 `;

--- a/spec/javascript/testUtils/wrapperUtil.js
+++ b/spec/javascript/testUtils/wrapperUtil.js
@@ -78,3 +78,8 @@ export const findByNameAndProps = (wrapper, name, props) => {
 
   return wrapper.findWhere(predicate)
 }
+
+export const findWithText = (wrapper, nodeName, text) => {
+  const predicate = n => n.name() === nodeName && n.text() === text
+  return wrapper.findWhere(predicate)
+}


### PR DESCRIPTION
Ticket: [DAH-123]

Confirm lease deletion with a modal.

I think all of the other acceptance criteria on this ticket have been completed in other prs:
1. When the lease modal is open and unsaved, when the user uses the status sidebar to save the application, we save the lease too and the lease changes to the "saved" state where the user has to click edit to edit again.
   - Added in lease save PR
2. When a Lease is deleted, also delete associated rental assistances
   - added in DAH-93 delete pr: https://github.com/SFDigitalServices/sf-dahlia-lap/pull/404
3. Display a confirmation modal for deletion
   - added in this PR
4. If a user has an unsaved lease and they try to click to the short form, display the warning modal about losing changes (use existing modal)
   - This just works automatically. Note that it doesn't ask to confirm if all you're done is clicked "Create Lease", I think that's okay.

[DAH-123]: https://sfgovdt.jira.com/browse/DAH-123