### PR TITLE
Remove extra GET request on delete confirm

### DIFF
--- a/app/javascript/components/organisms/ConfirmationModal.js
+++ b/app/javascript/components/organisms/ConfirmationModal.js
@@ -31,14 +31,23 @@ const ConfirmationModal = ({
         </Modal.Content>
         <Modal.Footer>
           <div className='modal-button_item modal-button_secondary'>
-            <a
-              className={buttonClasses}
-              href={primaryButtonDestination || '#'}
-              type='button'
-              onClick={onPrimaryClick}
-            >
-              {primaryText}
-            </a>
+            {primaryButtonDestination
+              ? <a
+                className={buttonClasses}
+                href={primaryButtonDestination}
+                type='button'
+                onClick={onPrimaryClick}
+              >
+                {primaryText}
+              </a>
+              : <button
+                className={buttonClasses}
+                type='button'
+                onClick={onPrimaryClick}
+              >
+                {primaryText}
+              </button>
+            }
           </div>
           <div className='modal-button_item modal-button_secondary'>
             <button className='button no-border' onClick={onSecondaryClick} type='button'>

--- a/spec/javascript/components/organisms/ConfirmationModal.test.js
+++ b/spec/javascript/components/organisms/ConfirmationModal.test.js
@@ -49,14 +49,13 @@ describe('ConfirmationModal', () => {
       expect(wrapper.find(Modal.Header).prop('id')).toEqual('confirmation-modal-header')
     })
 
-    test('should render the primary button as a link with href=#', () => {
-      const primaryButtonWrapper = findWithText(wrapper, 'a', PRIMARY_TEXT)
-      expect(primaryButtonWrapper).toHaveLength(1)
-      expect(primaryButtonWrapper.prop('href')).toEqual('#')
+    test('should render the primary button as a <button />', () => {
+      expect(findWithText(wrapper, 'button', PRIMARY_TEXT)).toHaveLength(1)
+      expect(findWithText(wrapper, 'a', PRIMARY_TEXT)).toHaveLength(0)
     })
 
     test('should render the primary button with primary style', () => {
-      const primaryWrapper = findWithText(wrapper, 'a', PRIMARY_TEXT)
+      const primaryWrapper = findWithText(wrapper, 'button', PRIMARY_TEXT)
       expect(primaryWrapper.prop('className').includes('primary')).toBeTruthy()
     })
 
@@ -77,7 +76,7 @@ describe('ConfirmationModal', () => {
     })
 
     test('should trigger the onPrimaryClick listener when primary button is clicked', () => {
-      findWithText(wrapper, 'a', PRIMARY_TEXT).simulate('click')
+      findWithText(wrapper, 'button', PRIMARY_TEXT).simulate('click')
 
       expect(ON_CLOSE.mock.calls.length).toEqual(0)
       expect(ON_PRIMARY_CLICK.mock.calls.length).toEqual(1)
@@ -124,21 +123,34 @@ describe('ConfirmationModal', () => {
     })
 
     test('should render the primary button with alert styling', () => {
-      const primaryWrapper = findWithText(wrapper, 'a', PRIMARY_TEXT)
+      const primaryWrapper = findWithText(wrapper, 'button', PRIMARY_TEXT)
       expect(primaryWrapper.prop('className').includes('alert')).toBeTruthy()
     })
   })
 
   describe('when primaryButtonDestination is provided', () => {
-    const DESTINATION = '/destinationPath'
+    const DESTINATION = '#'
     let wrapper
     beforeEach(() => {
       wrapper = getWrapper({ primaryButtonDestination: DESTINATION })
     })
 
+    test('should render the primary button as an <a /> component', () => {
+      expect(findWithText(wrapper, 'a', PRIMARY_TEXT)).toHaveLength(1)
+      expect(findWithText(wrapper, 'button', PRIMARY_TEXT)).toHaveLength(0)
+    })
+
     test('should render the primary button with the correct href', () => {
       const primaryWrapper = findWithText(wrapper, 'a', PRIMARY_TEXT)
       expect(primaryWrapper.prop('href')).toEqual(DESTINATION)
+    })
+
+    test('should trigger the onPrimaryClick listener when primary button is clicked', () => {
+      findWithText(wrapper, 'a', PRIMARY_TEXT).simulate('click')
+
+      expect(ON_CLOSE.mock.calls.length).toEqual(0)
+      expect(ON_PRIMARY_CLICK.mock.calls.length).toEqual(1)
+      expect(ON_SECONDARY_CLICK.mock.calls.length).toEqual(0)
     })
   })
 })


### PR DESCRIPTION
Turns out `<a href="#" />` triggers a GET request on click.

This only used a link when a button destination is provided, otherwise it renders as a regular button.

![- 2020-09-17 at 4 18 38 PM](https://user-images.githubusercontent.com/64036574/93537837-761b3700-f901-11ea-9dfa-2da74cfc57c8.png)
