### PR TITLE
Fix supp app saving on lease save clicked [DAH-550][DAH-549]

### DIFF
--- a/app/javascript/components/supplemental_application/SupplementalApplicationContainer.js
+++ b/app/javascript/components/supplemental_application/SupplementalApplicationContainer.js
@@ -122,11 +122,12 @@ const SupplementalApplicationContainer = ({ store }) => {
     const errors = { lease: {} }
     // only validate lease_start_date when any of the fields is present
     if (!isEmpty(values.lease) && !isEmpty(values.lease.lease_start_date)) {
-      errors.lease = { lease_start_date: {} }
-      validate.isValidDate(
-        values.lease.lease_start_date,
-        errors.lease.lease_start_date
-      )
+      const dateErrors = validate.isValidDate(values.lease.lease_start_date, {})
+
+      // only set any error fields if there were actually any date errors.
+      if (dateErrors?.all || dateErrors?.day || dateErrors?.month || dateErrors?.year) {
+        errors.lease.lease_start_date = dateErrors
+      }
     }
     return errors
   }
@@ -170,7 +171,10 @@ const SupplementalApplicationContainer = ({ store }) => {
 
   return (
     <Form
-      onSubmit={values => onSubmit(convertPercentAndCurrency(values))}
+      onSubmit={values => {
+        console.log('in form onsubmit')
+        return onSubmit(convertPercentAndCurrency(values))
+      }}
       initialValues={application}
       // Keep dirty on reinitialize ensures the whole form doesn't refresh
       // when only a piece of it is saved (eg. when the lease is saved)

--- a/app/javascript/components/supplemental_application/SupplementalApplicationContainer.js
+++ b/app/javascript/components/supplemental_application/SupplementalApplicationContainer.js
@@ -172,7 +172,6 @@ const SupplementalApplicationContainer = ({ store }) => {
   return (
     <Form
       onSubmit={values => {
-        console.log('in form onsubmit')
         return onSubmit(convertPercentAndCurrency(values))
       }}
       initialValues={application}

--- a/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
+++ b/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
@@ -78,8 +78,6 @@ class SupplementalApplicationPage extends React.Component {
       leaseSectionState
     } = this.state
 
-    console.log('IN HANDLE SAVE APPLICATION')
-
     this.setLoading(true)
 
     updateApplication(

--- a/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
+++ b/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
@@ -78,6 +78,8 @@ class SupplementalApplicationPage extends React.Component {
       leaseSectionState
     } = this.state
 
+    console.log('IN HANDLE SAVE APPLICATION')
+
     this.setLoading(true)
 
     updateApplication(

--- a/app/javascript/components/supplemental_application/sections/Lease.js
+++ b/app/javascript/components/supplemental_application/sections/Lease.js
@@ -60,7 +60,7 @@ const LeaseActions = ({
         onClick={onSave}
         disabled={loading}
         noBottomMargin
-        text='Save Lease'
+        text={loading ? 'Saving...' : 'Save Lease'}
       />
       <Button
         classes='secondary'
@@ -133,8 +133,11 @@ const Lease = ({ form, values, store }) => {
 
   const validateAndSaveLease = (form) => {
     if (areLeaseAndRentalAssistancesValid(form)) {
+      console.log('leaser valid')
       handleSaveLease(convertPercentAndCurrency(form.getState().values))
     } else {
+      console.log('leaser NOT valid')
+
       // submit to force errors to display
       form.submit()
     }

--- a/app/javascript/components/supplemental_application/sections/Lease.js
+++ b/app/javascript/components/supplemental_application/sections/Lease.js
@@ -133,11 +133,8 @@ const Lease = ({ form, values, store }) => {
 
   const validateAndSaveLease = (form) => {
     if (areLeaseAndRentalAssistancesValid(form)) {
-      console.log('leaser valid')
       handleSaveLease(convertPercentAndCurrency(form.getState().values))
     } else {
-      console.log('leaser NOT valid')
-
       // submit to force errors to display
       form.submit()
     }

--- a/app/javascript/components/supplemental_application/sections/RentalAssistance.js
+++ b/app/javascript/components/supplemental_application/sections/RentalAssistance.js
@@ -236,7 +236,7 @@ export const RentalAssistanceForm = ({
             onClick={handleSave}
             disabled={loading}
             noBottomMargin
-            text='Save'
+            text={loading ? 'Saving...' : 'Save'}
             id='rental-assistance-save'
           />
           <Button

--- a/app/javascript/utils/form/formSectionValidations.js
+++ b/app/javascript/utils/form/formSectionValidations.js
@@ -5,12 +5,16 @@ export const isSingleRentalAssistanceValid = (form, rentalAssistanceIndex) => {
   return isEmpty(assistanceErrors) || isEmpty(assistanceErrors[rentalAssistanceIndex])
 }
 
+export const isLeaseValid = (form) => {
+  const leaseErrors = form.getState().errors.lease
+  return isEmpty(leaseErrors) || leaseErrors.every(isEmpty)
+}
+
 export const areAllRentalAssistancesValid = (form) => {
   const assistanceErrors = form.getState().errors.rental_assistances
   return isEmpty(assistanceErrors) || assistanceErrors.every(isEmpty)
 }
 
 export const areLeaseAndRentalAssistancesValid = (form) => {
-  const leaseErrors = form.getState().errors.lease
-  return isEmpty(leaseErrors) && areAllRentalAssistancesValid(form)
+  return isLeaseValid(form) && areAllRentalAssistancesValid(form)
 }

--- a/app/javascript/utils/form/formSectionValidations.js
+++ b/app/javascript/utils/form/formSectionValidations.js
@@ -7,7 +7,7 @@ export const isSingleRentalAssistanceValid = (form, rentalAssistanceIndex) => {
 
 export const isLeaseValid = (form) => {
   const leaseErrors = form.getState().errors.lease
-  return isEmpty(leaseErrors) || leaseErrors.every(isEmpty)
+  return isEmpty(leaseErrors)
 }
 
 export const areAllRentalAssistancesValid = (form) => {

--- a/spec/javascript/components/supplemental_application/sections/RentalAssistance.test.js
+++ b/spec/javascript/components/supplemental_application/sections/RentalAssistance.test.js
@@ -125,7 +125,8 @@ describe('RentalAssistanceForm', () => {
     onSave = () => {},
     onClose = () => {},
     onDelete = () => {},
-    shouldMount = false
+    shouldMount = false,
+    loading = false
   }) => {
     const context = cloneDeep(baseContext)
     context.application.rental_assistances = assistance ? [assistance] : []
@@ -142,6 +143,7 @@ describe('RentalAssistanceForm', () => {
           onSave={onSave}
           onClose={onClose}
           onDelete={onDelete}
+          loading={loading}
         />
       ),
       shouldMount
@@ -171,6 +173,62 @@ describe('RentalAssistanceForm', () => {
 
     findByNameAndProps(wrapper, 'Button', { text: 'Save' }).simulate('click')
     expect(wrapper.find('.rental-assistance-type.error').exists()).toBeTruthy()
+  })
+
+  describe('when not loading', () => {
+    let wrapper
+    let saveButtonWrapper
+    let cancelButtonWrapper
+    let deleteButtonWrapper
+
+    beforeEach(() => {
+      wrapper = getWrapper({
+        assistance: rentalAssistance,
+        loading: false
+      })
+
+      saveButtonWrapper = findByNameAndProps(wrapper, 'Button', { id: 'rental-assistance-save' })
+      cancelButtonWrapper = findByNameAndProps(wrapper, 'Button', { id: 'rental-assistance-cancel' })
+      deleteButtonWrapper = findByNameAndProps(wrapper, 'Button', { id: 'rental-assistance-delete' })
+    })
+
+    test('should disable the action buttons', () => {
+      expect(saveButtonWrapper.props().disabled).toEqual(false)
+      expect(cancelButtonWrapper.props().disabled).toEqual(false)
+      expect(deleteButtonWrapper.props().disabled).toEqual(false)
+    })
+
+    test('should update the save button to say Saving...', () => {
+      expect(saveButtonWrapper.props().text).toEqual('Save')
+    })
+  })
+
+  describe('when loading', () => {
+    let wrapper
+    let saveButtonWrapper
+    let cancelButtonWrapper
+    let deleteButtonWrapper
+
+    beforeEach(() => {
+      wrapper = getWrapper({
+        assistance: rentalAssistance,
+        loading: true
+      })
+
+      saveButtonWrapper = findByNameAndProps(wrapper, 'Button', { id: 'rental-assistance-save' })
+      cancelButtonWrapper = findByNameAndProps(wrapper, 'Button', { id: 'rental-assistance-cancel' })
+      deleteButtonWrapper = findByNameAndProps(wrapper, 'Button', { id: 'rental-assistance-delete' })
+    })
+
+    test('should disable the action buttons', () => {
+      expect(saveButtonWrapper.props().disabled).toEqual(true)
+      expect(cancelButtonWrapper.props().disabled).toEqual(true)
+      expect(deleteButtonWrapper.props().disabled).toEqual(true)
+    })
+
+    test('should update the save button to say Saving...', () => {
+      expect(saveButtonWrapper.props().text).toEqual('Saving...')
+    })
   })
 
   describe('when it is new', () => {

--- a/spec/javascript/components/supplemental_application/sections/__snapshots__/RentalAssistance.test.js.snap
+++ b/spec/javascript/components/supplemental_application/sections/__snapshots__/RentalAssistance.test.js.snap
@@ -208,6 +208,7 @@ exports[`RentalAssistanceForm when it already exists on salesforce matches snaps
     >
       <Button
         classes="primary margin-right"
+        disabled={false}
         id="rental-assistance-save"
         noBottomMargin={true}
         onClick={[Function]}
@@ -217,6 +218,7 @@ exports[`RentalAssistanceForm when it already exists on salesforce matches snaps
       />
       <Button
         classes="secondary"
+        disabled={false}
         id="rental-assistance-cancel"
         noBottomMargin={true}
         onClick={[MockFunction]}
@@ -226,6 +228,7 @@ exports[`RentalAssistanceForm when it already exists on salesforce matches snaps
       />
       <Button
         classes="alert-fill right"
+        disabled={false}
         id="rental-assistance-delete"
         noBottomMargin={true}
         onClick={[MockFunction]}
@@ -373,6 +376,7 @@ exports[`RentalAssistanceForm when it is new matches snapshot 1`] = `
     >
       <Button
         classes="primary margin-right"
+        disabled={false}
         id="rental-assistance-save"
         noBottomMargin={true}
         onClick={[Function]}
@@ -382,6 +386,7 @@ exports[`RentalAssistanceForm when it is new matches snapshot 1`] = `
       />
       <Button
         classes="secondary"
+        disabled={false}
         id="rental-assistance-cancel"
         noBottomMargin={true}
         onClick={[MockFunction]}

--- a/spec/javascript/utils/form/formSectionValidations.test.js
+++ b/spec/javascript/utils/form/formSectionValidations.test.js
@@ -1,4 +1,5 @@
 import {
+  isLeaseValid,
   isSingleRentalAssistanceValid,
   areAllRentalAssistancesValid,
   areLeaseAndRentalAssistancesValid
@@ -20,6 +21,19 @@ const mockFormErrors = ({ assistanceErrors, leaseErrors }) => ({
 })
 
 const mockFormWithAssistanceErrors = (errors) => mockFormErrors({ assistanceErrors: errors })
+
+describe('isLeaseValid', () => {
+  test('should return true with empty errors', () => {
+    expect(isLeaseValid(mockFormErrors({ leaseErrors: undefined }))).toBeTruthy()
+    expect(isLeaseValid(mockFormErrors({ leaseErrors: {} }))).toBeTruthy()
+  })
+
+  test('should return false with non-empty errors', () => {
+    expect(isLeaseValid(mockFormErrors({ leaseErrors: ERROR }))).toBeFalsy()
+    expect(isLeaseValid(mockFormErrors({ leaseErrors: { lease_start_date: ERROR } }))).toBeFalsy()
+    expect(isLeaseValid(mockFormErrors({ leaseErrors: { lease_start_date: { all: ERROR } } }))).toBeFalsy()
+  })
+})
 
 describe('isSingleRentalAssistanceValid', () => {
   test('should return true when rental assistance errors are null', () => {
@@ -92,6 +106,7 @@ describe('areLeaseAndRentalAssistancesValid', () => {
 
     return areLeaseAndRentalAssistancesValid(form)
   }
+
   describe('with undefined rental assistances', () => {
     const assistanceErrors = undefined
 


### PR DESCRIPTION
[DAH-550][DAH-549]

## DAH-550
Just made it so that the lease and rental assistance save buttons say "Saving..." when a request is in progress.
![- 2020-10-05 at 3 22 29 PM](https://user-images.githubusercontent.com/64036574/95140485-d8f33780-0723-11eb-91d0-1ea75eb595fd.png)

Note: Even if you're just saving the lease or rental assistance, all save buttons will say "Saving...". I think this is okay

## DAH-549
### The issue
Supplemental app was saving when changes were made to the lease and lease save is clicked

### The cause
During validation, we thought the lease had errors when it really didn't. This caused us to trigger `form.submit()` to show those non-existent errors, but since there were no real errors, the form actually tried to submit!

### The fix
Change validation to not change the errors object if no errors were found.


[DAH-550]: https://sfgovdt.jira.com/browse/DAH-550
[DAH-549]: https://sfgovdt.jira.com/browse/DAH-549