### PR TITLE
[rev3] Fix preference used select [DAH-551]

### DIFF
--- a/app/javascript/components/supplemental_application/sections/Lease.js
+++ b/app/javascript/components/supplemental_application/sections/Lease.js
@@ -20,6 +20,8 @@ import { EDIT_LEASE_STATE } from '../SupplementalApplicationPage'
 import { doesApplicationHaveLease } from '~/utils/leaseUtils'
 import { areLeaseAndRentalAssistancesValid } from '~/utils/form/formSectionValidations'
 
+const NONE_PREFERENCE_LABEL = 'None'
+
 const toggleNoPreferenceUsed = (form, event) => {
   // lease.preference_used need to be reset, otherwise SF validation fails
   if (isEmpty(event.target.value)) {
@@ -27,6 +29,7 @@ const toggleNoPreferenceUsed = (form, event) => {
   }
   form.change('lease.no_preference_used', isEmpty(event.target.value))
 }
+
 const LeaseActions = ({
   onEditLeaseClick,
   onSave,
@@ -105,17 +108,14 @@ const Lease = ({ form, values, store }) => {
     map(availableUnits, pluck('id', 'unit_number'))
   )
 
-  const noUnitsOptions = [{ value: '', label: 'No Units Available' }]
+  const noUnitsOptions = [formUtils.toEmptyOption('No Units Available')]
   const confirmedPreferences = filter(application.preferences, {
     post_lottery_validation: 'Confirmed'
   })
-
-  const confirmedPreferenceOptions = formUtils.toOptions(
-    map(
-      [{ id: null, preference_name: 'None' }, ...confirmedPreferences],
-      pluck('id', 'preference_name')
-    )
-  )
+  const confirmedPreferenceOptions = formUtils.toOptions([
+    formUtils.toEmptyOption(NONE_PREFERENCE_LABEL),
+    ...map(confirmedPreferences, pluck('id', 'preference_name'))
+  ])
 
   const getVisited = (fieldName) => (
     form.getFieldState(fieldName)?.visited
@@ -217,6 +217,7 @@ const Lease = ({ form, values, store }) => {
           <FormGrid.Item>
             <SelectField
               label='Preference Used'
+              selectValue={values.lease.preference_used || NONE_PREFERENCE_LABEL}
               onChange={value => toggleNoPreferenceUsed(form, value)}
               fieldName='lease.preference_used'
               options={confirmedPreferenceOptions}

--- a/spec/javascript/components/supplemental_application/__snapshots__/SupplementalApplicationPage.test.js.snap
+++ b/spec/javascript/components/supplemental_application/__snapshots__/SupplementalApplicationPage.test.js.snap
@@ -4601,7 +4601,7 @@ Array [
                         value="a0w0P00000MOzyXQAT"
                       >
                         <option
-                          value={null}
+                          value=""
                         >
                           None
                         </option>


### PR DESCRIPTION
[DAH-551]

## The issue
Switching "Preference used" to "None" and clicking save would cause an error because we were passing the literal string "None" to the backend.

### The cause
The way SelectField works, if you have a value of `null`, it will treat the label as the value. Instead the value needs to be set as an empty string. This is really confusing

### The fix
we should always use FormUtils.toEmptyOption to create empty options to avoid this.

I verified that setting the form value to an empty string still saves the preference as null on the backend.

[DAH-551]: https://sfgovdt.jira.com/browse/DAH-551