### PR TITLE
Fix onChanged modal not showing for new lease [DAH-548]

### DIFF
--- a/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
+++ b/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
@@ -355,7 +355,10 @@ class SupplementalApplicationPage extends React.Component {
   }
 
   handleLeaveSuppAppTab = () => {
-    if (this.state.supplementalAppTouched) {
+    const { application, supplementalAppTouched, leaseSectionState } = this.state
+
+    const hasStartedNewLease = leaseSectionState === EDIT_LEASE_STATE && !doesApplicationHaveLease(application)
+    if (supplementalAppTouched || hasStartedNewLease) {
       this.setState({ leaveConfirmationModal: { isOpen: true } })
     } else {
       window.location.href = appPaths.toLeaseUpShortForm(this.state.application.id)
@@ -411,7 +414,6 @@ class SupplementalApplicationPage extends React.Component {
       handleDeleteLease: this.handleDeleteLease,
       handleCloseRentalAssistancePanel: this.handleCloseRentalAssistancePanel,
       handleDeleteRentalAssistance: this.handleDeleteRentalAssistance,
-      handleOpenRentalAssistancePanel: this.handleOpenRentalAssistancePanel,
       handleSaveRentalAssistance: this.handleSaveRentalAssistance,
       handleStatusModalClose: this.handleStatusModalClose,
       handleStatusModalStatusChange: this.handleStatusModalStatusChange,


### PR DESCRIPTION
[DAH-548]

QA testing description:
> While testing part 17, navigating away from the supp app with saved changes works as expected. Navigating away with an unsaved newly created lease does NOT throw an unsaved changes modal, but should. On return does not have the lease saved, as expected. Navigating away with non-lease unsaved changes also does NOT throw an unsaved changes modal, but should. On return, the changes are reverted, as expected.

## The bug
create a new lease (but don't save it), and navigate away from the page. A modal should pop up asking if you want to discard your changes but it doesn't.

## The fix
When navigating away from the page, add an additional check to see if you're in the "editing a new lease" state. Note that once you've made any edits to the lease the modal will show up properly, so we only need this special case when the lease is new and untouched.

I was unable to reproduce the issue where making changes outside of the lease section didn't trigger the modal to show.

[DAH-548]: https://sfgovdt.jira.com/browse/DAH-548