### PR TITLE
Merge release fixes

### DIFF
--- a/app/javascript/components/supplemental_application/SupplementalApplicationContainer.js
+++ b/app/javascript/components/supplemental_application/SupplementalApplicationContainer.js
@@ -122,8 +122,12 @@ const SupplementalApplicationContainer = ({ store }) => {
     const errors = { lease: {} }
     // only validate lease_start_date when any of the fields is present
     if (!isEmpty(values.lease) && !isEmpty(values.lease.lease_start_date)) {
-      errors.lease = { lease_start_date: {} }
-      validate.isValidDate(values.lease.lease_start_date, errors.lease.lease_start_date)
+      const dateErrors = validate.isValidDate(values.lease.lease_start_date, {})
+
+      // only set any error fields if there were actually any date errors.
+      if (dateErrors?.all || dateErrors?.day || dateErrors?.month || dateErrors?.year) {
+        errors.lease.lease_start_date = dateErrors
+      }
     }
     return errors
   }

--- a/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
+++ b/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
@@ -367,7 +367,11 @@ class SupplementalApplicationPage extends React.Component {
   }
 
   handleLeaveSuppAppTab = () => {
-    if (this.state.supplementalAppTouched) {
+    const { application, supplementalAppTouched, leaseSectionState } = this.state
+
+    const hasStartedNewLease =
+      leaseSectionState === EDIT_LEASE_STATE && !doesApplicationHaveLease(application)
+    if (supplementalAppTouched || hasStartedNewLease) {
       this.setState({ leaveConfirmationModal: { isOpen: true } })
     } else {
       window.location.href = appPaths.toLeaseUpShortForm(this.state.application.id)
@@ -423,7 +427,6 @@ class SupplementalApplicationPage extends React.Component {
       handleDeleteLease: this.handleDeleteLease,
       handleCloseRentalAssistancePanel: this.handleCloseRentalAssistancePanel,
       handleDeleteRentalAssistance: this.handleDeleteRentalAssistance,
-      handleOpenRentalAssistancePanel: this.handleOpenRentalAssistancePanel,
       handleSaveRentalAssistance: this.handleSaveRentalAssistance,
       handleStatusModalClose: this.handleStatusModalClose,
       handleStatusModalStatusChange: this.handleStatusModalStatusChange,

--- a/app/javascript/components/supplemental_application/sections/Lease.js
+++ b/app/javascript/components/supplemental_application/sections/Lease.js
@@ -20,6 +20,8 @@ import { EDIT_LEASE_STATE } from '../SupplementalApplicationPage'
 import { doesApplicationHaveLease } from '~/utils/leaseUtils'
 import { areLeaseAndRentalAssistancesValid } from '~/utils/form/formSectionValidations'
 
+const NONE_PREFERENCE_LABEL = 'None'
+
 const toggleNoPreferenceUsed = (form, event) => {
   // lease.preference_used need to be reset, otherwise SF validation fails
   if (isEmpty(event.target.value)) {
@@ -27,6 +29,7 @@ const toggleNoPreferenceUsed = (form, event) => {
   }
   form.change('lease.no_preference_used', isEmpty(event.target.value))
 }
+
 const LeaseActions = ({
   onEditLeaseClick,
   onSave,
@@ -111,17 +114,14 @@ const Lease = ({ form, values, store }) => {
       return unit.priority_type && unit.priority_type.match(/Mobility|Hearing|Vision/)
     })
 
-  const noUnitsOptions = [{ value: '', label: 'No Units Available' }]
+  const noUnitsOptions = [formUtils.toEmptyOption('No Units Available')]
   const confirmedPreferences = filter(application.preferences, {
     post_lottery_validation: 'Confirmed'
   })
-
-  const confirmedPreferenceOptions = formUtils.toOptions(
-    map(
-      [{ id: null, preference_name: 'None' }, ...confirmedPreferences],
-      pluck('id', 'preference_name')
-    )
-  )
+  const confirmedPreferenceOptions = formUtils.toOptions([
+    formUtils.toEmptyOption(NONE_PREFERENCE_LABEL),
+    ...map(confirmedPreferences, pluck('id', 'preference_name'))
+  ])
 
   const getVisited = (fieldName) => form.getFieldState(fieldName)?.visited
 
@@ -261,6 +261,7 @@ const Lease = ({ form, values, store }) => {
             <SelectField
               label='Preference Used'
               onChange={(value) => toggleNoPreferenceUsed(form, value)}
+              selectValue={values.lease.preference_used || NONE_PREFERENCE_LABEL}
               fieldName='lease.preference_used'
               options={confirmedPreferenceOptions}
               disabled={disabled}

--- a/app/javascript/components/supplemental_application/sections/Lease.js
+++ b/app/javascript/components/supplemental_application/sections/Lease.js
@@ -60,7 +60,7 @@ const LeaseActions = ({
         onClick={onSave}
         disabled={loading}
         noBottomMargin
-        text='Save Lease'
+        text={loading ? 'Saving...' : 'Save Lease'}
       />
       <Button
         classes='secondary'

--- a/app/javascript/components/supplemental_application/sections/RentalAssistance.js
+++ b/app/javascript/components/supplemental_application/sections/RentalAssistance.js
@@ -234,7 +234,7 @@ export const RentalAssistanceForm = ({
             onClick={handleSave}
             disabled={loading}
             noBottomMargin
-            text='Save'
+            text={loading ? 'Saving...' : 'Save'}
             id='rental-assistance-save'
           />
           <Button

--- a/app/javascript/utils/form/formSectionValidations.js
+++ b/app/javascript/utils/form/formSectionValidations.js
@@ -5,12 +5,16 @@ export const isSingleRentalAssistanceValid = (form, rentalAssistanceIndex) => {
   return isEmpty(assistanceErrors) || isEmpty(assistanceErrors[rentalAssistanceIndex])
 }
 
+export const isLeaseValid = (form) => {
+  const leaseErrors = form.getState().errors.lease
+  return isEmpty(leaseErrors)
+}
+
 export const areAllRentalAssistancesValid = (form) => {
   const assistanceErrors = form.getState().errors.rental_assistances
   return isEmpty(assistanceErrors) || assistanceErrors.every(isEmpty)
 }
 
 export const areLeaseAndRentalAssistancesValid = (form) => {
-  const leaseErrors = form.getState().errors.lease
-  return isEmpty(leaseErrors) && areAllRentalAssistancesValid(form)
+  return isLeaseValid(form) && areAllRentalAssistancesValid(form)
 }

--- a/spec/javascript/components/supplemental_application/__snapshots__/SupplementalApplicationPage.test.js.snap
+++ b/spec/javascript/components/supplemental_application/__snapshots__/SupplementalApplicationPage.test.js.snap
@@ -4717,7 +4717,7 @@ Array [
                         value="a0w0P00000MOzyXQAT"
                       >
                         <option
-                          value={null}
+                          value=""
                         >
                           None
                         </option>

--- a/spec/javascript/components/supplemental_application/sections/RentalAssistance.test.js
+++ b/spec/javascript/components/supplemental_application/sections/RentalAssistance.test.js
@@ -120,7 +120,8 @@ describe('RentalAssistanceForm', () => {
     onSave = () => {},
     onClose = () => {},
     onDelete = () => {},
-    shouldMount = false
+    shouldMount = false,
+    loading = false
   }) => {
     const context = cloneDeep(baseContext)
     context.application.rental_assistances = assistance ? [assistance] : []
@@ -137,6 +138,7 @@ describe('RentalAssistanceForm', () => {
           onSave={onSave}
           onClose={onClose}
           onDelete={onDelete}
+          loading={loading}
         />
       ),
       shouldMount
@@ -166,6 +168,70 @@ describe('RentalAssistanceForm', () => {
 
     findByNameAndProps(wrapper, 'Button', { text: 'Save' }).simulate('click')
     expect(wrapper.find('.rental-assistance-type.error').exists()).toBeTruthy()
+  })
+
+  describe('when not loading', () => {
+    let wrapper
+    let saveButtonWrapper
+    let cancelButtonWrapper
+    let deleteButtonWrapper
+
+    beforeEach(() => {
+      wrapper = getWrapper({
+        assistance: rentalAssistance,
+        loading: false
+      })
+
+      saveButtonWrapper = findByNameAndProps(wrapper, 'Button', { id: 'rental-assistance-save' })
+      cancelButtonWrapper = findByNameAndProps(wrapper, 'Button', {
+        id: 'rental-assistance-cancel'
+      })
+      deleteButtonWrapper = findByNameAndProps(wrapper, 'Button', {
+        id: 'rental-assistance-delete'
+      })
+    })
+
+    test('should disable the action buttons', () => {
+      expect(saveButtonWrapper.props().disabled).toEqual(false)
+      expect(cancelButtonWrapper.props().disabled).toEqual(false)
+      expect(deleteButtonWrapper.props().disabled).toEqual(false)
+    })
+
+    test('should update the save button to say Saving...', () => {
+      expect(saveButtonWrapper.props().text).toEqual('Save')
+    })
+  })
+
+  describe('when loading', () => {
+    let wrapper
+    let saveButtonWrapper
+    let cancelButtonWrapper
+    let deleteButtonWrapper
+
+    beforeEach(() => {
+      wrapper = getWrapper({
+        assistance: rentalAssistance,
+        loading: true
+      })
+
+      saveButtonWrapper = findByNameAndProps(wrapper, 'Button', { id: 'rental-assistance-save' })
+      cancelButtonWrapper = findByNameAndProps(wrapper, 'Button', {
+        id: 'rental-assistance-cancel'
+      })
+      deleteButtonWrapper = findByNameAndProps(wrapper, 'Button', {
+        id: 'rental-assistance-delete'
+      })
+    })
+
+    test('should disable the action buttons', () => {
+      expect(saveButtonWrapper.props().disabled).toEqual(true)
+      expect(cancelButtonWrapper.props().disabled).toEqual(true)
+      expect(deleteButtonWrapper.props().disabled).toEqual(true)
+    })
+
+    test('should update the save button to say Saving...', () => {
+      expect(saveButtonWrapper.props().text).toEqual('Saving...')
+    })
   })
 
   describe('when it is new', () => {

--- a/spec/javascript/components/supplemental_application/sections/__snapshots__/RentalAssistance.test.js.snap
+++ b/spec/javascript/components/supplemental_application/sections/__snapshots__/RentalAssistance.test.js.snap
@@ -208,6 +208,7 @@ exports[`RentalAssistanceForm when it already exists on salesforce matches snaps
     >
       <Button
         classes="primary margin-right"
+        disabled={false}
         id="rental-assistance-save"
         noBottomMargin={true}
         onClick={[Function]}
@@ -217,6 +218,7 @@ exports[`RentalAssistanceForm when it already exists on salesforce matches snaps
       />
       <Button
         classes="secondary"
+        disabled={false}
         id="rental-assistance-cancel"
         noBottomMargin={true}
         onClick={[MockFunction]}
@@ -226,6 +228,7 @@ exports[`RentalAssistanceForm when it already exists on salesforce matches snaps
       />
       <Button
         classes="alert-fill right"
+        disabled={false}
         id="rental-assistance-delete"
         noBottomMargin={true}
         onClick={[MockFunction]}
@@ -373,6 +376,7 @@ exports[`RentalAssistanceForm when it is new matches snapshot 1`] = `
     >
       <Button
         classes="primary margin-right"
+        disabled={false}
         id="rental-assistance-save"
         noBottomMargin={true}
         onClick={[Function]}
@@ -382,6 +386,7 @@ exports[`RentalAssistanceForm when it is new matches snapshot 1`] = `
       />
       <Button
         classes="secondary"
+        disabled={false}
         id="rental-assistance-cancel"
         noBottomMargin={true}
         onClick={[MockFunction]}

--- a/spec/javascript/utils/form/formSectionValidations.test.js
+++ b/spec/javascript/utils/form/formSectionValidations.test.js
@@ -1,4 +1,5 @@
 import {
+  isLeaseValid,
   isSingleRentalAssistanceValid,
   areAllRentalAssistancesValid,
   areLeaseAndRentalAssistancesValid
@@ -20,6 +21,21 @@ const mockFormErrors = ({ assistanceErrors, leaseErrors }) => ({
 })
 
 const mockFormWithAssistanceErrors = (errors) => mockFormErrors({ assistanceErrors: errors })
+
+describe('isLeaseValid', () => {
+  test('should return true with empty errors', () => {
+    expect(isLeaseValid(mockFormErrors({ leaseErrors: undefined }))).toBeTruthy()
+    expect(isLeaseValid(mockFormErrors({ leaseErrors: {} }))).toBeTruthy()
+  })
+
+  test('should return false with non-empty errors', () => {
+    expect(isLeaseValid(mockFormErrors({ leaseErrors: ERROR }))).toBeFalsy()
+    expect(isLeaseValid(mockFormErrors({ leaseErrors: { lease_start_date: ERROR } }))).toBeFalsy()
+    expect(
+      isLeaseValid(mockFormErrors({ leaseErrors: { lease_start_date: { all: ERROR } } }))
+    ).toBeFalsy()
+  })
+})
 
 describe('isSingleRentalAssistanceValid', () => {
   test('should return true when rental assistance errors are null', () => {
@@ -92,6 +108,7 @@ describe('areLeaseAndRentalAssistancesValid', () => {
 
     return areLeaseAndRentalAssistancesValid(form)
   }
+
   describe('with undefined rental assistances', () => {
     const assistanceErrors = undefined
 


### PR DESCRIPTION
### Cherry-picks these fixes onto main
Fix supp app saving on lease save clicked [DAH-550] [DAH-549] (#422)
Fix preference used select [DAH-551] (#423)
Fix onChanged modal not showing for new lease [DAH-548] (#424) 

Each of them had merge conflicts because of the new linting rules, they were all resolved manually.

I think we should wait to merge this until we've QA'd the fixes

[DAH-550]: https://sfgovdt.jira.com/browse/DAH-550
[DAH-549]: https://sfgovdt.jira.com/browse/DAH-549
[DAH-551]: https://sfgovdt.jira.com/browse/DAH-551
[DAH-548]: https://sfgovdt.jira.com/browse/DAH-548