### PR TITLE
Load pages via react-router [DAH-42]

### DIFF
--- a/app/controllers/applications/supplementals_controller.rb
+++ b/app/controllers/applications/supplementals_controller.rb
@@ -5,10 +5,6 @@ module Applications
   class SupplementalsController < ApplicationController
     before_action :authenticate_user!
 
-    def index
-      @application_id = params[:application_id]
-    end
-
     def update
       application_service.update
     end

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -9,14 +9,6 @@ class ApplicationsController < ApplicationController
     @listings = soql_listing_service.pre_lottery_listings
   end
 
-  def show
-    # TODO: Move these fields into the frontend code
-    # once react-routing is set up.
-    @application_id = params[:id]
-    @is_lease_up = params[:lease_up] == 'true'
-    @show_add_btn = params[:showAddBtn]
-  end
-
   def edit
     @application = soql_application_service.application(params[:id])
     @listing = soql_listing_service.listing(@application[:listing_id])

--- a/app/controllers/listings/lease_ups/applications_controller.rb
+++ b/app/controllers/listings/lease_ups/applications_controller.rb
@@ -4,9 +4,5 @@ module Listings::LeaseUps
   # Rails controller for views/actions related to applications for a listing that has Lease Up status
   class ApplicationsController < ApplicationController
     before_action :authenticate_user!
-
-    def index
-      @listing_id = params[:lease_up_id]
-    end
   end
 end

--- a/app/javascript/components/applications/ApplicationPage.js
+++ b/app/javascript/components/applications/ApplicationPage.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
+import { useParams } from 'react-router-dom'
 import { isEmpty } from 'lodash'
-import { useEffectOnMount } from '~/utils/customHooks'
+import { useEffectOnMount, useQueryParamBoolean } from '~/utils/customHooks'
 import { getShortFormApplication } from '~/components/lease_ups/shortFormActions'
 import ApplicationDetails from './application_details/ApplicationDetails'
 import CardLayout from '../layouts/CardLayout'
@@ -24,7 +25,7 @@ const buildActionLinkIfNecessary = (app, showAddBtn) => {
     )
   }
 
-  if (showAddBtn === 'true') {
+  if (showAddBtn) {
     actions.push(
       <a
         key='add-new-application'
@@ -39,10 +40,14 @@ const buildActionLinkIfNecessary = (app, showAddBtn) => {
   return actions
 }
 
-const ApplicationPage = ({ applicationId, showAddBtn, isLeaseUp }) => {
+const ApplicationPage = () => {
   const [application, setApplication] = useState(null)
   const [fileBaseUrl, setFileBaseUrl] = useState(null)
   const [loading, setLoading] = useState(true)
+
+  const { applicationId } = useParams()
+  const isLeaseUp = useQueryParamBoolean('lease_up')
+  const showAddBtn = useQueryParamBoolean('showAddBtn')
 
   useEffectOnMount(() => {
     getShortFormApplication(applicationId)

--- a/app/javascript/components/lease_ups/LeaseUpApplicationsPage.js
+++ b/app/javascript/components/lease_ups/LeaseUpApplicationsPage.js
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react'
 import { map, each, set, clone } from 'lodash'
+import { useParams } from 'react-router-dom'
 import moment from 'moment'
 import { getApplications, getListing } from './leaseUpActions'
 
@@ -46,7 +47,7 @@ const getPreferences = (listing) => {
   return map(listing.listing_lottery_preferences, (pref) => pref.lottery_preference.name)
 }
 
-const LeaseUpApplicationsPage = ({ listingId }) => {
+const LeaseUpApplicationsPage = () => {
   const [state, overrideEntireState] = useState({
     loading: false,
     applications: [],
@@ -65,6 +66,9 @@ const LeaseUpApplicationsPage = ({ listingId }) => {
     listing: null,
     eagerPagination: new EagerPagination(ROWS_PER_PAGE, SERVER_PAGE_SIZE)
   })
+
+  // grab the listing id from the url: /lease-ups/listings/:listingId
+  const { listingId } = useParams()
 
   const performAsyncRequest = ({
     initialState = {},

--- a/app/javascript/packs/react_application.js
+++ b/app/javascript/packs/react_application.js
@@ -4,15 +4,11 @@ import ReactModal from 'react-modal'
 
 import ApplicationEditPage from 'components/applications/ApplicationEditPage'
 import ApplicationNewPage from 'components/applications/ApplicationNewPage'
-import ApplicationPage from 'components/applications/ApplicationPage'
 import ApplicationsPage from 'components/applications/ApplicationsPage'
 import FlaggedApplicationsIndexPage from 'components/applications/flagged/FlaggedApplicationsIndexPage'
 import FlaggedApplicationsShowPage from 'components/applications/flagged/FlaggedApplicationsShowPage'
 
 import LeaseUpApp from 'routes/LeaseUpApp'
-import LeaseUpApplicationsPage from 'components/lease_ups/LeaseUpApplicationsPage'
-import LeaseUpListingsPage from 'components/lease_ups/LeaseUpListingsPage'
-import SupplementalApplicationPage from 'components/supplemental_application/SupplementalApplicationPage'
 
 import ListingApplicationsPage from 'components/listings/ListingApplicationsPage'
 import ListingPage from 'components/listings/ListingPage'
@@ -26,18 +22,14 @@ Turbolinks.start()
 
 WebpackerReact.setup({ ApplicationEditPage }) // ES6 shorthand for {ApplicationEditPage: ApplicationEditPage}
 WebpackerReact.setup({ ApplicationNewPage })
-WebpackerReact.setup({ ApplicationPage })
 WebpackerReact.setup({ ApplicationsPage })
 WebpackerReact.setup({ FlaggedApplicationsIndexPage })
 WebpackerReact.setup({ FlaggedApplicationsShowPage })
-WebpackerReact.setup({ SupplementalApplicationPage })
 WebpackerReact.setup({ ListingApplicationsPage })
 WebpackerReact.setup({ ListingPage })
 WebpackerReact.setup({ ListingsPage })
 WebpackerReact.setup({ HomePage })
-WebpackerReact.setup({ LeaseUpApplicationsPage })
 WebpackerReact.setup({ LeaseUpApp })
-WebpackerReact.setup({ LeaseUpListingsPage })
 
 window.onload = () => {
   ReactModal.setAppElement('#root')

--- a/app/javascript/packs/react_application.js
+++ b/app/javascript/packs/react_application.js
@@ -9,6 +9,7 @@ import ApplicationsPage from 'components/applications/ApplicationsPage'
 import FlaggedApplicationsIndexPage from 'components/applications/flagged/FlaggedApplicationsIndexPage'
 import FlaggedApplicationsShowPage from 'components/applications/flagged/FlaggedApplicationsShowPage'
 
+import LeaseUpApp from 'routes/LeaseUpApp'
 import LeaseUpApplicationsPage from 'components/lease_ups/LeaseUpApplicationsPage'
 import LeaseUpListingsPage from 'components/lease_ups/LeaseUpListingsPage'
 import SupplementalApplicationPage from 'components/supplemental_application/SupplementalApplicationPage'
@@ -35,6 +36,7 @@ WebpackerReact.setup({ ListingPage })
 WebpackerReact.setup({ ListingsPage })
 WebpackerReact.setup({ HomePage })
 WebpackerReact.setup({ LeaseUpApplicationsPage })
+WebpackerReact.setup({ LeaseUpApp })
 WebpackerReact.setup({ LeaseUpListingsPage })
 
 window.onload = () => {

--- a/app/javascript/routes/LeaseUpApp.js
+++ b/app/javascript/routes/LeaseUpApp.js
@@ -1,0 +1,12 @@
+import React from 'react'
+// import ReactDOM from 'react-dom'
+import { BrowserRouter as Router } from 'react-router-dom'
+import LeaseUpRoutes from './LeaseUpRoutes'
+
+const LeaseUpApp = () => (
+  <Router>
+    <LeaseUpRoutes />
+  </Router>
+)
+
+export default LeaseUpApp

--- a/app/javascript/routes/LeaseUpRoutes.js
+++ b/app/javascript/routes/LeaseUpRoutes.js
@@ -1,0 +1,33 @@
+import React from 'react'
+// import ReactDOM from 'react-dom'
+import { Switch, Route } from 'react-router-dom'
+
+import LeaseUpApplicationsPage from '~/components/lease_ups/LeaseUpApplicationsPage'
+import SupplementalApplicationPage from '~/components/supplemental_application/SupplementalApplicationPage'
+import LeaseUpListingsPage from '~/components/lease_ups/LeaseUpListingsPage'
+import ApplicationPage from '~/components/applications/ApplicationPage'
+
+const LeaseUpRoutes = () => (
+  <Switch>
+    <Route exact path='/listings/lease-ups/:listingId/applications'>
+      <LeaseUpApplicationsPage />
+    </Route>
+    <Route exact path='/listings/lease-ups'>
+      <LeaseUpListingsPage />
+    </Route>
+    <Route
+      exact
+      path='/applications/:applicationId/supplementals'
+      render={({ match }) => (
+        // TODO: Convert SupplementalApplicationPage to functional components and use
+        // hooks to get path params.
+        <SupplementalApplicationPage applicationId={match.params.applicationId} />
+      )}
+    />
+    <Route exact path='/applications/:applicationId'>
+      <ApplicationPage />
+    </Route>
+  </Switch>
+)
+
+export default LeaseUpRoutes

--- a/app/javascript/utils/customHooks.js
+++ b/app/javascript/utils/customHooks.js
@@ -1,4 +1,5 @@
 import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
 
 /**
  * Perform the useEffect hook one time only on component mount.
@@ -11,3 +12,23 @@ import { useEffect } from 'react'
  */
 // eslint-disable-next-line react-hooks/exhaustive-deps
 export const useEffectOnMount = (f) => useEffect(f, [])
+
+/**
+ * Get the url param if it exists. This is only usable in a react routed component,
+ * because it uses the useLocation() hook.
+ *
+ * @param {String} paramName
+ */
+export const useQueryParam = (paramName) => new URLSearchParams(useLocation().search).get(paramName)
+
+/**
+ * Get a boolean query parameter from the url, if it's not specified, return defaultValue.
+ */
+export const useQueryParamBoolean = (paramName, defaultValue = false) => {
+  const param = useQueryParam(paramName)
+  if (param == null) {
+    return defaultValue
+  }
+
+  return param === 'true'
+}

--- a/app/views/applications/show.html.slim
+++ b/app/views/applications/show.html.slim
@@ -1,6 +1,3 @@
 / include webpacked react-table CSS
 == stylesheet_pack_tag 'react-table'
-== react_component 'ApplicationPage', { \
-  applicationId: @application_id,
-  showAddBtn: @show_add_btn,
-  isLeaseUp: @is_lease_up}
+== react_component 'LeaseUpApp'

--- a/app/views/applications/supplementals/index.slim
+++ b/app/views/applications/supplementals/index.slim
@@ -1,1 +1,1 @@
-== react_component 'SupplementalApplicationPage', { applicationId: @application_id }
+== react_component 'LeaseUpApp'

--- a/app/views/listings/lease_ups/applications/index.html.slim
+++ b/app/views/listings/lease_ups/applications/index.html.slim
@@ -1,1 +1,1 @@
-== react_component 'LeaseUpApplicationsPage', { listingId: @listing_id }
+== react_component 'LeaseUpApp'

--- a/app/views/listings/lease_ups/index.slim
+++ b/app/views/listings/lease_ups/index.slim
@@ -1,1 +1,1 @@
-== react_component 'LeaseUpListingsPage'
+== react_component 'LeaseUpApp'

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-json-tree": "^0.11.2",
     "react-modal": "^3.8.1",
     "react-popper": "^2.2.3",
+    "react-router-dom": "^5.2.0",
     "react-select": "^3.1.0",
     "react-table": "^6.9.2",
     "turbolinks": "^5.0.3",

--- a/spec/controllers/applications_controller_spec.rb
+++ b/spec/controllers/applications_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ApplicationsController, type: :controller do
         get :show, params: { id: non_lease_up_application_id }
       end
 
-      expect(response.body).to have_react_component('ApplicationPage')
+      expect(response.body).to have_react_component('LeaseUpApp')
       expect(response).to have_http_status(:success)
     end
   end

--- a/spec/controllers/supplementals_controller_spec.rb
+++ b/spec/controllers/supplementals_controller_spec.rb
@@ -7,10 +7,13 @@ RSpec.describe Applications::SupplementalsController, type: :controller do
   login_admin
 
   describe '#index' do
-    it 'should pass the application ID to the frontend' do
-      get :index, params: { application_id: lease_up_application_id }
-      application_id = assigns(:application_id)
-      expect(application_id).to eq(lease_up_application_id)
+    it 'should render the page successfully' do
+      VCR.use_cassette('controllers/supplementals/index') do
+        get :index, params: { application_id: lease_up_application_id }
+      end
+
+      expect(response.body).to have_react_component('LeaseUpApp')
+      expect(response).to have_http_status(:success)
     end
   end
 end

--- a/spec/javascript/components/applications/__snapshots__/ApplicationPage.test.js.snap
+++ b/spec/javascript/components/applications/__snapshots__/ApplicationPage.test.js.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ApplicationPage with regular application After the application finishes loading should match snapshot 1`] = `
-<ApplicationPage
-  applicationId="regular_app_id"
->
+<ApplicationPage>
   <Loading
     isLoading={false}
   >

--- a/spec/javascript/components/lease_ups/LeaseUpApplicationsPage.test.js
+++ b/spec/javascript/components/lease_ups/LeaseUpApplicationsPage.test.js
@@ -1,9 +1,10 @@
 /* eslint-disable jest/no-conditional-expect */
 import React from 'react'
-import { mount, shallow } from 'enzyme'
+import { mount } from 'enzyme'
+import { withRouter } from '../../testUtils/wrapperUtil'
 import { act } from 'react-dom/test-utils'
 import LeaseUpApplicationsPage from '~/components/lease_ups/LeaseUpApplicationsPage'
-import Context from '~/components/lease_ups/context'
+import Loading from '~/components/molecules/Loading'
 
 import TableLayout from '~/components/layouts/TableLayout'
 import LeaseUpApplicationsTableContainer from '~/components/lease_ups/LeaseUpApplicationsTableContainer'
@@ -12,12 +13,6 @@ import StatusModalWrapper from '~/components/organisms/StatusModalWrapper'
 const mockGetLeaseUpListing = jest.fn()
 const mockFetchLeaseUpApplications = jest.fn()
 const mockCreateFieldUpdateComment = jest.fn()
-
-const tick = () => {
-  return new Promise((resolve) => {
-    setTimeout(resolve, 0)
-  })
-}
 
 jest.mock('apiService', () => {
   return {
@@ -76,17 +71,59 @@ const mockApplications = [
 ]
 
 const rowSelector = 'div.rt-tbody .rt-tr-group'
-let wrapper
 
-describe('LeaseUpApplicationsPage', () => {
-  beforeEach(async () => {
-    wrapper = mount(<LeaseUpApplicationsPage listingId={mockListing.id} />)
-    await act(tick)
-    wrapper.update()
+const getWrapper = async () => {
+  let wrapper
+  await act(async () => {
+    wrapper = mount(
+      withRouter(
+        '/listings/lease-ups/:listingId/applications',
+        `/listings/lease-ups/${mockListing.id}/applications`,
+        <LeaseUpApplicationsPage />
+      )
+    )
   })
 
-  test('should render LeaseUpTable', async () => {
-    expect(wrapper).toMatchSnapshot()
+  wrapper.update()
+  return wrapper
+}
+
+describe('LeaseUpApplicationsPage', () => {
+  let wrapper
+  beforeEach(async () => {
+    wrapper = await getWrapper()
+  })
+
+  test('should match the snapshot', async () => {
+    expect(wrapper.find(LeaseUpApplicationsPage)).toMatchSnapshot()
+  })
+
+  test('renders the table', () => {
+    expect(wrapper.find(LeaseUpApplicationsTableContainer)).toHaveLength(1)
+  })
+
+  test('calls get listing with the listing id', () => {
+    expect(mockGetLeaseUpListing.mock.calls).toHaveLength(1)
+    expect(mockGetLeaseUpListing.mock.calls[0][0]).toEqual(mockListing.id)
+  })
+
+  test('calls get applications with the listing id and page number = 0', () => {
+    expect(mockFetchLeaseUpApplications.mock.calls).toHaveLength(1)
+    expect(mockFetchLeaseUpApplications.mock.calls[0][0]).toEqual(mockListing.id)
+    expect(mockFetchLeaseUpApplications.mock.calls[0][1]).toEqual(0)
+  })
+
+  test('it is not loading', () => {
+    expect(wrapper.find(Loading).props().isLoading).toBeFalsy()
+  })
+
+  test('renders the header properly', () => {
+    expect(wrapper.find(TableLayout)).toHaveLength(1)
+    const headerProps = wrapper.find(TableLayout).prop('pageHeader')
+    expect(headerProps.title).toEqual(mockListing.name)
+    expect(headerProps.content).toEqual(mockListing.building_street_address)
+    expect(headerProps.action.title).toEqual('Export')
+    expect(headerProps.breadcrumbs).toHaveLength(2)
   })
 
   test('should render accessibility requests when present', async () => {
@@ -118,95 +155,5 @@ describe('LeaseUpApplicationsPage', () => {
 
     // if submit wasn't clicked we shouldn't trigger an API request
     expect(mockCreateFieldUpdateComment).not.toHaveBeenCalled()
-  })
-})
-
-describe('LeaseUpApplicationsPage (shallow)', () => {
-  let wrapper
-  beforeEach(() => {
-    wrapper = shallow(<LeaseUpApplicationsPage listingId={mockListing.id} />)
-  })
-
-  describe('before the listing is loaded', () => {
-    test('renders the table', () => {
-      expect(wrapper.find(LeaseUpApplicationsTableContainer)).toHaveLength(1)
-    })
-
-    test('is not loading', () => {
-      expect(wrapper.find(Context.Provider).props().value.loading).toBeFalsy()
-    })
-
-    test('no api calls are made', () => {
-      expect(mockGetLeaseUpListing.mock.calls).toHaveLength(0)
-      expect(mockFetchLeaseUpApplications.mock.calls).toHaveLength(0)
-    })
-
-    test('renders the header properly', () => {
-      expect(wrapper.find(TableLayout)).toHaveLength(1)
-      const headerProps = wrapper.find(TableLayout).prop('pageHeader')
-      expect(headerProps.title).toEqual('')
-      expect(headerProps.content).toEqual('')
-      expect(headerProps.action).toBeNull()
-      expect(headerProps.breadcrumbs).toHaveLength(1)
-    })
-  })
-
-  describe('when handleOnFetchData is called with page=0', () => {
-    beforeEach(() => {
-      wrapper.find(Context.Provider).props().value.handleOnFetchData({ page: 0, filters: {} })
-    })
-
-    test('is loading', () => {
-      expect(wrapper.find(Context.Provider).props().value.loading).toBeTruthy()
-    })
-
-    test('calls get listing with the listing id', () => {
-      expect(mockGetLeaseUpListing.mock.calls).toHaveLength(1)
-      expect(mockGetLeaseUpListing.mock.calls[0][0]).toEqual(mockListing.id)
-    })
-
-    test('calls get applications with the listing id and page number = 0', () => {
-      expect(mockFetchLeaseUpApplications.mock.calls).toHaveLength(1)
-      expect(mockFetchLeaseUpApplications.mock.calls[0][0]).toEqual(mockListing.id)
-      expect(mockFetchLeaseUpApplications.mock.calls[0][1]).toEqual(0)
-    })
-
-    describe('when data fetching finishes', () => {
-      beforeEach(async () => {
-        await act(tick)
-      })
-
-      test('it is not loading anymore', () => {
-        expect(wrapper.find(Context.Provider).props().value.loading).toBeFalsy()
-      })
-
-      test('renders the header properly', () => {
-        expect(wrapper.find(TableLayout)).toHaveLength(1)
-        const headerProps = wrapper.find(TableLayout).prop('pageHeader')
-        expect(headerProps.title).toEqual(mockListing.name)
-        expect(headerProps.content).toEqual(mockListing.building_street_address)
-        expect(headerProps.action.title).toEqual('Export')
-        expect(headerProps.breadcrumbs).toHaveLength(2)
-      })
-
-      describe('when a second page is loaded', () => {
-        beforeEach(() => {
-          wrapper.find(Context.Provider).props().value.handleOnFetchData({ page: 6, filters: {} })
-        })
-
-        test('only called getListing once (from the initial page load)', () => {
-          expect(mockGetLeaseUpListing.mock.calls).toHaveLength(1)
-        })
-
-        test('calls get applications twice (once for each page load)', () => {
-          expect(mockFetchLeaseUpApplications.mock.calls).toHaveLength(2)
-          expect(mockFetchLeaseUpApplications.mock.calls[1][0]).toEqual(mockListing.id)
-
-          // It's confusing but this page param is actually the server page, so even though
-          // the client, "eager" page is 6 the server page is only 1.
-          expect(mockFetchLeaseUpApplications.mock.calls[1][1]).toEqual(1)
-        })
-      })
-    })
   })
 })

--- a/spec/javascript/components/lease_ups/__snapshots__/LeaseUpApplicationsPage.test.js.snap
+++ b/spec/javascript/components/lease_ups/__snapshots__/LeaseUpApplicationsPage.test.js.snap
@@ -4942,7 +4942,7 @@ exports[`LeaseUpApplicationsPage should match the snapshot 1`] = `
                                                                           <DummyInput
                                                                             aria-autocomplete="list"
                                                                             disabled={false}
-                                                                            id="react-select-57-input"
+                                                                            id="react-select-7-input"
                                                                             innerRef={[Function]}
                                                                             onBlur={[Function]}
                                                                             onChange={[Function]}
@@ -4965,7 +4965,7 @@ exports[`LeaseUpApplicationsPage should match the snapshot 1`] = `
                                                                                 }
                                                                               }
                                                                               disabled={false}
-                                                                              id="react-select-57-input"
+                                                                              id="react-select-7-input"
                                                                               onBlur={[Function]}
                                                                               onChange={[Function]}
                                                                               onFocus={[Function]}
@@ -4977,7 +4977,7 @@ exports[`LeaseUpApplicationsPage should match the snapshot 1`] = `
                                                                                 aria-autocomplete="list"
                                                                                 className="css-62g3xt-dummyInput"
                                                                                 disabled={false}
-                                                                                id="react-select-57-input"
+                                                                                id="react-select-7-input"
                                                                                 onBlur={[Function]}
                                                                                 onChange={[Function]}
                                                                                 onFocus={[Function]}
@@ -8292,7 +8292,7 @@ exports[`LeaseUpApplicationsPage should match the snapshot 1`] = `
                                                                           <DummyInput
                                                                             aria-autocomplete="list"
                                                                             disabled={false}
-                                                                            id="react-select-58-input"
+                                                                            id="react-select-8-input"
                                                                             innerRef={[Function]}
                                                                             onBlur={[Function]}
                                                                             onChange={[Function]}
@@ -8315,7 +8315,7 @@ exports[`LeaseUpApplicationsPage should match the snapshot 1`] = `
                                                                                 }
                                                                               }
                                                                               disabled={false}
-                                                                              id="react-select-58-input"
+                                                                              id="react-select-8-input"
                                                                               onBlur={[Function]}
                                                                               onChange={[Function]}
                                                                               onFocus={[Function]}
@@ -8327,7 +8327,7 @@ exports[`LeaseUpApplicationsPage should match the snapshot 1`] = `
                                                                                 aria-autocomplete="list"
                                                                                 className="css-62g3xt-dummyInput"
                                                                                 disabled={false}
-                                                                                id="react-select-58-input"
+                                                                                id="react-select-8-input"
                                                                                 onBlur={[Function]}
                                                                                 onChange={[Function]}
                                                                                 onFocus={[Function]}
@@ -11642,7 +11642,7 @@ exports[`LeaseUpApplicationsPage should match the snapshot 1`] = `
                                                                           <DummyInput
                                                                             aria-autocomplete="list"
                                                                             disabled={false}
-                                                                            id="react-select-59-input"
+                                                                            id="react-select-9-input"
                                                                             innerRef={[Function]}
                                                                             onBlur={[Function]}
                                                                             onChange={[Function]}
@@ -11665,7 +11665,7 @@ exports[`LeaseUpApplicationsPage should match the snapshot 1`] = `
                                                                                 }
                                                                               }
                                                                               disabled={false}
-                                                                              id="react-select-59-input"
+                                                                              id="react-select-9-input"
                                                                               onBlur={[Function]}
                                                                               onChange={[Function]}
                                                                               onFocus={[Function]}
@@ -11677,7 +11677,7 @@ exports[`LeaseUpApplicationsPage should match the snapshot 1`] = `
                                                                                 aria-autocomplete="list"
                                                                                 className="css-62g3xt-dummyInput"
                                                                                 disabled={false}
-                                                                                id="react-select-59-input"
+                                                                                id="react-select-9-input"
                                                                                 onBlur={[Function]}
                                                                                 onChange={[Function]}
                                                                                 onFocus={[Function]}
@@ -14992,7 +14992,7 @@ exports[`LeaseUpApplicationsPage should match the snapshot 1`] = `
                                                                           <DummyInput
                                                                             aria-autocomplete="list"
                                                                             disabled={false}
-                                                                            id="react-select-60-input"
+                                                                            id="react-select-10-input"
                                                                             innerRef={[Function]}
                                                                             onBlur={[Function]}
                                                                             onChange={[Function]}
@@ -15015,7 +15015,7 @@ exports[`LeaseUpApplicationsPage should match the snapshot 1`] = `
                                                                                 }
                                                                               }
                                                                               disabled={false}
-                                                                              id="react-select-60-input"
+                                                                              id="react-select-10-input"
                                                                               onBlur={[Function]}
                                                                               onChange={[Function]}
                                                                               onFocus={[Function]}
@@ -15027,7 +15027,7 @@ exports[`LeaseUpApplicationsPage should match the snapshot 1`] = `
                                                                                 aria-autocomplete="list"
                                                                                 className="css-62g3xt-dummyInput"
                                                                                 disabled={false}
-                                                                                id="react-select-60-input"
+                                                                                id="react-select-10-input"
                                                                                 onBlur={[Function]}
                                                                                 onChange={[Function]}
                                                                                 onFocus={[Function]}
@@ -18342,7 +18342,7 @@ exports[`LeaseUpApplicationsPage should match the snapshot 1`] = `
                                                                           <DummyInput
                                                                             aria-autocomplete="list"
                                                                             disabled={false}
-                                                                            id="react-select-61-input"
+                                                                            id="react-select-11-input"
                                                                             innerRef={[Function]}
                                                                             onBlur={[Function]}
                                                                             onChange={[Function]}
@@ -18365,7 +18365,7 @@ exports[`LeaseUpApplicationsPage should match the snapshot 1`] = `
                                                                                 }
                                                                               }
                                                                               disabled={false}
-                                                                              id="react-select-61-input"
+                                                                              id="react-select-11-input"
                                                                               onBlur={[Function]}
                                                                               onChange={[Function]}
                                                                               onFocus={[Function]}
@@ -18377,7 +18377,7 @@ exports[`LeaseUpApplicationsPage should match the snapshot 1`] = `
                                                                                 aria-autocomplete="list"
                                                                                 className="css-62g3xt-dummyInput"
                                                                                 disabled={false}
-                                                                                id="react-select-61-input"
+                                                                                id="react-select-11-input"
                                                                                 onBlur={[Function]}
                                                                                 onChange={[Function]}
                                                                                 onFocus={[Function]}

--- a/spec/javascript/components/lease_ups/__snapshots__/LeaseUpApplicationsPage.test.js.snap
+++ b/spec/javascript/components/lease_ups/__snapshots__/LeaseUpApplicationsPage.test.js.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`LeaseUpApplicationsPage should render LeaseUpTable 1`] = `
-<LeaseUpApplicationsPage
-  listingId="listingId"
->
+exports[`LeaseUpApplicationsPage should match the snapshot 1`] = `
+<LeaseUpApplicationsPage>
   <TableLayout
     pageHeader={
       Object {
@@ -4944,7 +4942,7 @@ exports[`LeaseUpApplicationsPage should render LeaseUpTable 1`] = `
                                                                           <DummyInput
                                                                             aria-autocomplete="list"
                                                                             disabled={false}
-                                                                            id="react-select-7-input"
+                                                                            id="react-select-57-input"
                                                                             innerRef={[Function]}
                                                                             onBlur={[Function]}
                                                                             onChange={[Function]}
@@ -4967,7 +4965,7 @@ exports[`LeaseUpApplicationsPage should render LeaseUpTable 1`] = `
                                                                                 }
                                                                               }
                                                                               disabled={false}
-                                                                              id="react-select-7-input"
+                                                                              id="react-select-57-input"
                                                                               onBlur={[Function]}
                                                                               onChange={[Function]}
                                                                               onFocus={[Function]}
@@ -4979,7 +4977,7 @@ exports[`LeaseUpApplicationsPage should render LeaseUpTable 1`] = `
                                                                                 aria-autocomplete="list"
                                                                                 className="css-62g3xt-dummyInput"
                                                                                 disabled={false}
-                                                                                id="react-select-7-input"
+                                                                                id="react-select-57-input"
                                                                                 onBlur={[Function]}
                                                                                 onChange={[Function]}
                                                                                 onFocus={[Function]}
@@ -8294,7 +8292,7 @@ exports[`LeaseUpApplicationsPage should render LeaseUpTable 1`] = `
                                                                           <DummyInput
                                                                             aria-autocomplete="list"
                                                                             disabled={false}
-                                                                            id="react-select-8-input"
+                                                                            id="react-select-58-input"
                                                                             innerRef={[Function]}
                                                                             onBlur={[Function]}
                                                                             onChange={[Function]}
@@ -8317,7 +8315,7 @@ exports[`LeaseUpApplicationsPage should render LeaseUpTable 1`] = `
                                                                                 }
                                                                               }
                                                                               disabled={false}
-                                                                              id="react-select-8-input"
+                                                                              id="react-select-58-input"
                                                                               onBlur={[Function]}
                                                                               onChange={[Function]}
                                                                               onFocus={[Function]}
@@ -8329,7 +8327,7 @@ exports[`LeaseUpApplicationsPage should render LeaseUpTable 1`] = `
                                                                                 aria-autocomplete="list"
                                                                                 className="css-62g3xt-dummyInput"
                                                                                 disabled={false}
-                                                                                id="react-select-8-input"
+                                                                                id="react-select-58-input"
                                                                                 onBlur={[Function]}
                                                                                 onChange={[Function]}
                                                                                 onFocus={[Function]}
@@ -11644,7 +11642,7 @@ exports[`LeaseUpApplicationsPage should render LeaseUpTable 1`] = `
                                                                           <DummyInput
                                                                             aria-autocomplete="list"
                                                                             disabled={false}
-                                                                            id="react-select-9-input"
+                                                                            id="react-select-59-input"
                                                                             innerRef={[Function]}
                                                                             onBlur={[Function]}
                                                                             onChange={[Function]}
@@ -11667,7 +11665,7 @@ exports[`LeaseUpApplicationsPage should render LeaseUpTable 1`] = `
                                                                                 }
                                                                               }
                                                                               disabled={false}
-                                                                              id="react-select-9-input"
+                                                                              id="react-select-59-input"
                                                                               onBlur={[Function]}
                                                                               onChange={[Function]}
                                                                               onFocus={[Function]}
@@ -11679,7 +11677,7 @@ exports[`LeaseUpApplicationsPage should render LeaseUpTable 1`] = `
                                                                                 aria-autocomplete="list"
                                                                                 className="css-62g3xt-dummyInput"
                                                                                 disabled={false}
-                                                                                id="react-select-9-input"
+                                                                                id="react-select-59-input"
                                                                                 onBlur={[Function]}
                                                                                 onChange={[Function]}
                                                                                 onFocus={[Function]}
@@ -14994,7 +14992,7 @@ exports[`LeaseUpApplicationsPage should render LeaseUpTable 1`] = `
                                                                           <DummyInput
                                                                             aria-autocomplete="list"
                                                                             disabled={false}
-                                                                            id="react-select-10-input"
+                                                                            id="react-select-60-input"
                                                                             innerRef={[Function]}
                                                                             onBlur={[Function]}
                                                                             onChange={[Function]}
@@ -15017,7 +15015,7 @@ exports[`LeaseUpApplicationsPage should render LeaseUpTable 1`] = `
                                                                                 }
                                                                               }
                                                                               disabled={false}
-                                                                              id="react-select-10-input"
+                                                                              id="react-select-60-input"
                                                                               onBlur={[Function]}
                                                                               onChange={[Function]}
                                                                               onFocus={[Function]}
@@ -15029,7 +15027,7 @@ exports[`LeaseUpApplicationsPage should render LeaseUpTable 1`] = `
                                                                                 aria-autocomplete="list"
                                                                                 className="css-62g3xt-dummyInput"
                                                                                 disabled={false}
-                                                                                id="react-select-10-input"
+                                                                                id="react-select-60-input"
                                                                                 onBlur={[Function]}
                                                                                 onChange={[Function]}
                                                                                 onFocus={[Function]}
@@ -18344,7 +18342,7 @@ exports[`LeaseUpApplicationsPage should render LeaseUpTable 1`] = `
                                                                           <DummyInput
                                                                             aria-autocomplete="list"
                                                                             disabled={false}
-                                                                            id="react-select-11-input"
+                                                                            id="react-select-61-input"
                                                                             innerRef={[Function]}
                                                                             onBlur={[Function]}
                                                                             onChange={[Function]}
@@ -18367,7 +18365,7 @@ exports[`LeaseUpApplicationsPage should render LeaseUpTable 1`] = `
                                                                                 }
                                                                               }
                                                                               disabled={false}
-                                                                              id="react-select-11-input"
+                                                                              id="react-select-61-input"
                                                                               onBlur={[Function]}
                                                                               onChange={[Function]}
                                                                               onFocus={[Function]}
@@ -18379,7 +18377,7 @@ exports[`LeaseUpApplicationsPage should render LeaseUpTable 1`] = `
                                                                                 aria-autocomplete="list"
                                                                                 className="css-62g3xt-dummyInput"
                                                                                 disabled={false}
-                                                                                id="react-select-11-input"
+                                                                                id="react-select-61-input"
                                                                                 onBlur={[Function]}
                                                                                 onChange={[Function]}
                                                                                 onFocus={[Function]}

--- a/spec/javascript/routes/LeaseUpRoutes.test.js
+++ b/spec/javascript/routes/LeaseUpRoutes.test.js
@@ -1,0 +1,140 @@
+import React from 'react'
+
+import { MemoryRouter as Router } from 'react-router-dom'
+import { mount } from 'enzyme'
+import LeaseUpRoutes from '~/routes/LeaseUpRoutes'
+
+jest.mock(
+  '../../../app/javascript/components/supplemental_application/SupplementalApplicationPage',
+  ({ id } = {}) => {
+    const MockSuppAppComponent = ({ applicationId }) => <div />
+    return {
+      __esModule: true,
+      default: ({ applicationId }) => {
+        return <MockSuppAppComponent applicationId={applicationId} />
+      }
+    }
+  }
+)
+
+jest.mock('../../../app/javascript/components/lease_ups/LeaseUpListingsPage', () => {
+  const MockListingsPageComponent = () => <div />
+  return {
+    __esModule: true,
+    default: () => {
+      return <MockListingsPageComponent />
+    }
+  }
+})
+
+jest.mock('../../../app/javascript/components/lease_ups/LeaseUpApplicationsPage', () => {
+  const MockApplicationsPageComponent = () => <div />
+  return {
+    __esModule: true,
+    default: () => {
+      return <MockApplicationsPageComponent />
+    }
+  }
+})
+
+jest.mock('../../../app/javascript/components/applications/ApplicationPage', () => {
+  const MockShortFormComponent = () => <div />
+  return {
+    __esModule: true,
+    default: () => {
+      return <MockShortFormComponent />
+    }
+  }
+})
+
+const MOCK_NAME_SUPP = 'MockSuppAppComponent'
+const MOCK_NAME_LISTINGS = 'MockListingsPageComponent'
+const MOCK_NAME_SHORT_FORM = 'MockShortFormComponent'
+const MOCK_NAME_APPLICATIONS = 'MockApplicationsPageComponent'
+
+const getWrapper = (url) => {
+  return mount(
+    <Router initialEntries={[url]}>
+      <LeaseUpRoutes />
+    </Router>
+  )
+}
+
+describe('LeaseUpRoutes', () => {
+  describe('applications for lease-up listing paths', () => {
+    test('should render the applications page when the exact path is passed in', () => {
+      const wrapper = getWrapper('/listings/lease-ups/testListingId/applications')
+      expect(wrapper.find(MOCK_NAME_APPLICATIONS)).toHaveLength(1)
+      expect(wrapper.find(MOCK_NAME_LISTINGS)).toHaveLength(0)
+      expect(wrapper.find(MOCK_NAME_SUPP)).toHaveLength(0)
+      expect(wrapper.find(MOCK_NAME_SHORT_FORM)).toHaveLength(0)
+    })
+
+    test('should not render anything when additional path params are provided', () => {
+      const wrapper = getWrapper('/listings/lease-ups/testListingId/applications/somethingElse')
+      expect(wrapper.find(MOCK_NAME_APPLICATIONS)).toHaveLength(0)
+      expect(wrapper.find(MOCK_NAME_LISTINGS)).toHaveLength(0)
+      expect(wrapper.find(MOCK_NAME_SUPP)).toHaveLength(0)
+      expect(wrapper.find(MOCK_NAME_SHORT_FORM)).toHaveLength(0)
+    })
+  })
+
+  describe('listings page paths', () => {
+    test('should render the listings page when the exact path is passed in', () => {
+      const wrapper = getWrapper('/listings/lease-ups')
+      expect(wrapper.find(MOCK_NAME_APPLICATIONS)).toHaveLength(0)
+      expect(wrapper.find(MOCK_NAME_LISTINGS)).toHaveLength(1)
+      expect(wrapper.find(MOCK_NAME_SUPP)).toHaveLength(0)
+      expect(wrapper.find(MOCK_NAME_SHORT_FORM)).toHaveLength(0)
+    })
+
+    test('should not render anything when additional path params are provided', () => {
+      const wrapper = getWrapper('/listings/lease-ups/somethingElse')
+      expect(wrapper.find(MOCK_NAME_APPLICATIONS)).toHaveLength(0)
+      expect(wrapper.find(MOCK_NAME_LISTINGS)).toHaveLength(0)
+      expect(wrapper.find(MOCK_NAME_SUPP)).toHaveLength(0)
+      expect(wrapper.find(MOCK_NAME_SHORT_FORM)).toHaveLength(0)
+    })
+  })
+
+  describe('supp app paths', () => {
+    test('should render the supp app page when the exact path is passed in', () => {
+      const wrapper = getWrapper('/applications/suppAppId/supplementals')
+      expect(wrapper.find(MOCK_NAME_APPLICATIONS)).toHaveLength(0)
+      expect(wrapper.find(MOCK_NAME_LISTINGS)).toHaveLength(0)
+      expect(wrapper.find(MOCK_NAME_SUPP)).toHaveLength(1)
+      expect(wrapper.find(MOCK_NAME_SHORT_FORM)).toHaveLength(0)
+    })
+
+    test('should not render anything when additional path params are provided', () => {
+      const wrapper = getWrapper('/applications/suppAppId/supplementals/somethingElse')
+      expect(wrapper.find(MOCK_NAME_APPLICATIONS)).toHaveLength(0)
+      expect(wrapper.find(MOCK_NAME_LISTINGS)).toHaveLength(0)
+      expect(wrapper.find(MOCK_NAME_SUPP)).toHaveLength(0)
+      expect(wrapper.find(MOCK_NAME_SHORT_FORM)).toHaveLength(0)
+    })
+
+    test('passes the id as a prop to the supp app', () => {
+      const wrapper = getWrapper('/applications/suppAppId/supplementals')
+      expect(wrapper.find(MOCK_NAME_SUPP).props().applicationId).toEqual('suppAppId')
+    })
+  })
+
+  describe('short form paths', () => {
+    test('should render the short form page when the exact path is passed in', () => {
+      const wrapper = getWrapper('/applications/testApplicationId')
+      expect(wrapper.find(MOCK_NAME_APPLICATIONS)).toHaveLength(0)
+      expect(wrapper.find(MOCK_NAME_LISTINGS)).toHaveLength(0)
+      expect(wrapper.find(MOCK_NAME_SUPP)).toHaveLength(0)
+      expect(wrapper.find(MOCK_NAME_SHORT_FORM)).toHaveLength(1)
+    })
+
+    test('should not render anything when additional path params are provided', () => {
+      const wrapper = getWrapper('/applications/testApplicationId/somethingElse')
+      expect(wrapper.find(MOCK_NAME_APPLICATIONS)).toHaveLength(0)
+      expect(wrapper.find(MOCK_NAME_LISTINGS)).toHaveLength(0)
+      expect(wrapper.find(MOCK_NAME_SUPP)).toHaveLength(0)
+      expect(wrapper.find(MOCK_NAME_SHORT_FORM)).toHaveLength(0)
+    })
+  })
+})

--- a/spec/javascript/testUtils/wrapperUtil.js
+++ b/spec/javascript/testUtils/wrapperUtil.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { shallow, mount } from 'enzyme'
 import Context from '~/components/supplemental_application/context'
 import { Form } from 'react-final-form'
+import { MemoryRouter as Router, Switch, Route } from 'react-router-dom'
 
 const formNode = (application, formToChildrenFunc) => (
   <Form
@@ -72,4 +73,14 @@ export const findByNameAndProps = (wrapper, name, props) => {
 export const findWithText = (wrapper, nodeName, text) => {
   const predicate = (n) => n.name() === nodeName && n.text() === text
   return wrapper.findWhere(predicate)
+}
+
+export const withRouter = (urlWithParamPlaceholders, url, children) => {
+  return (
+    <Router initialEntries={[url]}>
+      <Switch>
+        <Route path={urlWithParamPlaceholders}>{children}</Route>
+      </Switch>
+    </Router>
+  )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -881,6 +881,13 @@
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
 
+"@babel/runtime@^7.1.2":
+  version "7.12.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.0.tgz#98bd7666186969c04be893d747cf4a6c6c8fa6b0"
+  integrity sha512-lS4QLXQ2Vbw2ubfQjeQcn+BZgZ5+ROHW9f+DWjEp5Y+NHYmkRGKqHSJ1tuhbUauKu2nhZNTBIvsIQ8dXfY5Gjw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.10.0", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.9.2":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
@@ -6036,6 +6043,18 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
+history@^4.9.0:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
+  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    loose-envify "^1.2.0"
+    resolve-pathname "^3.0.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+    value-equal "^1.0.1"
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -6045,7 +6064,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -7776,7 +7795,7 @@ lolex@^5.0.0, lolex@^5.0.1:
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -8025,6 +8044,14 @@ min-document@^2.19.0:
   integrity sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=
   dependencies:
     dom-walk "^0.1.0"
+
+mini-create-react-context@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.4.0.tgz#df60501c83151db69e28eac0ef08b4002efab040"
+  integrity sha512-b0TytUgFSbgFJGzJqXPKCFCBWigAjpjo+Fl7Vf7ZbKRDptszpppKxXH6DRXEABZ/gcEQczeb0iZ7JvL8e8jjCA==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    tiny-warning "^1.0.3"
 
 mini-css-extract-plugin@^0.8.0:
   version "0.8.2"
@@ -10120,7 +10147,7 @@ react-input-autosize@^2.2.2:
   dependencies:
     prop-types "^15.5.8"
 
-react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6, react-is@^16.9.0:
+react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -10156,6 +10183,35 @@ react-popper@^2.2.3:
   dependencies:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
+
+react-router-dom@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.2.0.tgz#9e65a4d0c45e13289e66c7b17c7e175d0ea15662"
+  integrity sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    history "^4.9.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.6.2"
+    react-router "5.2.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+
+react-router@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.0.tgz#424e75641ca8747fbf76e5ecca69781aa37ea293"
+  integrity sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    history "^4.9.0"
+    hoist-non-react-statics "^3.1.0"
+    loose-envify "^1.3.1"
+    mini-create-react-context "^0.4.0"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.6.2"
+    react-is "^16.6.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
 
 react-select@^3.1.0:
   version "3.1.0"
@@ -10547,6 +10603,11 @@ resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+
+resolve-pathname@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
+  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
 resolve-url@^0.2.1:
   version "0.2.1"
@@ -11777,6 +11838,16 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
+tiny-invariant@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
+  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
+
+tiny-warning@^1.0.0, tiny-warning@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -12183,6 +12254,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+value-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
+  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
[DAH-42]

- Remove bootstrapped data, gather params from paths
- Add react-router package
- Set up LeaseUpApp router

todo: in follow-up PRs
- [ ] change paths to be formatted in the new way. This requires ruby changes so I want to do it in a separate PR
- [ ] connect single page app pages via react-router <Link /> components (currently it's not actually behaving like a single page app)

[DAH-42]: https://sfgovdt.jira.com/browse/DAH-42