### PR TITLE
Route application links [DAH-42]

### DIFF
--- a/app/javascript/components/lease_ups/LeaseUpApplicationsPage.js
+++ b/app/javascript/components/lease_ups/LeaseUpApplicationsPage.js
@@ -31,6 +31,11 @@ const getPageHeaderData = (listing) => {
     renderAsRouterLink: true
   }
 
+  const emptyBreadCrumb = {
+    title: '',
+    link: '#'
+  }
+
   const breadcrumbs = listing
     ? [
         levelAboveBreadcrumb,
@@ -40,7 +45,7 @@ const getPageHeaderData = (listing) => {
           renderAsRouterLink: true
         }
       ]
-    : [levelAboveBreadcrumb]
+    : [levelAboveBreadcrumb, emptyBreadCrumb]
 
   return {
     title: listing?.name || '',

--- a/app/javascript/components/lease_ups/LeaseUpApplicationsTable.js
+++ b/app/javascript/components/lease_ups/LeaseUpApplicationsTable.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import ReactTable from 'react-table'
 import { trim } from 'lodash'
+import { Link } from 'react-router-dom'
 
 import StatusDropdown from '../molecules/StatusDropdown'
 import { getLeaseUpStatusClass } from '~/utils/statusUtils'
@@ -82,12 +83,12 @@ const LeaseUpApplicationsTable = ({
       accessor: 'application_number',
       className: 'text-left',
       Cell: (cell) => (
-        <a
-          href={appPaths.toApplicationSupplementals(cell.original.application_id)}
+        <Link
+          to={appPaths.toApplicationSupplementals(cell.original.application_id)}
           className='has-border'
         >
           {cell.value}
-        </a>
+        </Link>
       )
     },
     { Header: 'First Name', accessor: 'first_name', Cell: resizableCell, className: 'text-left' },

--- a/spec/javascript/components/atoms/Breadcrumbs.test.js
+++ b/spec/javascript/components/atoms/Breadcrumbs.test.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import { NavLink } from 'react-router-dom'
 import BreadCrumbs, { Item } from 'components/atoms/BreadCrumbs'
-import { findByNameAndProps } from '../../testUtils/wrapperUtil'
+import { findWithProps } from '../../testUtils/wrapperUtil'
 import { uniq } from 'lodash'
 
 const mockCrumb = (title, link, renderAsRouterLink = undefined) => ({
@@ -99,8 +99,8 @@ describe('BreadCrumbs', () => {
     })
 
     test('renders the last item as current', () => {
-      expect(findByNameAndProps(wrapper, 'Item', { current: true })).toHaveLength(1)
-      expect(findByNameAndProps(wrapper, 'Item', { current: true }).props().item).toEqual(CRUMB_D)
+      expect(findWithProps(wrapper, Item, { current: true })).toHaveLength(1)
+      expect(findWithProps(wrapper, Item, { current: true }).props().item).toEqual(CRUMB_D)
     })
   })
 })

--- a/spec/javascript/components/lease_ups/LeaseUpApplicationsPage.test.js
+++ b/spec/javascript/components/lease_ups/LeaseUpApplicationsPage.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable jest/no-conditional-expect */
-import { mountAppWithUrl } from '../../testUtils/wrapperUtil'
+import { findWithText, mountAppWithUrl } from '../../testUtils/wrapperUtil'
 import { act } from 'react-dom/test-utils'
+import { Link } from 'react-router-dom'
 import LeaseUpApplicationsPage from '~/components/lease_ups/LeaseUpApplicationsPage'
 import Loading from '~/components/molecules/Loading'
 
@@ -120,6 +121,16 @@ describe('LeaseUpApplicationsPage', () => {
 
   test('should render accessibility requests when present', async () => {
     expect(wrapper.find(rowSelector).first().text()).toContain('Vision')
+  })
+
+  test('should render application links as routed links', () => {
+    const mockAppNames = mockApplications.map((app) => app.application.name)
+    const applicationLinkWrappers = mockAppNames.map((name) => findWithText(wrapper, Link, name))
+
+    // Just double check that our list has the same length as mockApplications, because if
+    // for some reason it had length 0 the .every(..) call would always return true by default
+    expect(applicationLinkWrappers).toHaveLength(5)
+    expect(applicationLinkWrappers.every((w) => w.exists())).toBeTruthy()
   })
 
   test('status modal can be opened and closed', () => {

--- a/spec/javascript/components/lease_ups/__snapshots__/LeaseUpApplicationsPage.test.js.snap
+++ b/spec/javascript/components/lease_ups/__snapshots__/LeaseUpApplicationsPage.test.js.snap
@@ -2399,12 +2399,24 @@ exports[`LeaseUpApplicationsPage should match the snapshot 1`] = `
                                         viewIndex={0}
                                         width={100}
                                       >
-                                        <a
+                                        <Link
                                           className="has-border"
-                                          href="/lease-ups/applications/10001/supplemental"
+                                          to="/lease-ups/applications/10001/supplemental"
                                         >
-                                          Application Name 1
-                                        </a>
+                                          <LinkAnchor
+                                            className="has-border"
+                                            href="/lease-ups/applications/10001/supplemental"
+                                            navigate={[Function]}
+                                          >
+                                            <a
+                                              className="has-border"
+                                              href="/lease-ups/applications/10001/supplemental"
+                                              onClick={[Function]}
+                                            >
+                                              Application Name 1
+                                            </a>
+                                          </LinkAnchor>
+                                        </Link>
                                       </Cell>
                                     </div>
                                   </TdComponent>
@@ -5776,12 +5788,24 @@ exports[`LeaseUpApplicationsPage should match the snapshot 1`] = `
                                         viewIndex={1}
                                         width={100}
                                       >
-                                        <a
+                                        <Link
                                           className="has-border"
-                                          href="/lease-ups/applications/10002/supplemental"
+                                          to="/lease-ups/applications/10002/supplemental"
                                         >
-                                          Application Name 2
-                                        </a>
+                                          <LinkAnchor
+                                            className="has-border"
+                                            href="/lease-ups/applications/10002/supplemental"
+                                            navigate={[Function]}
+                                          >
+                                            <a
+                                              className="has-border"
+                                              href="/lease-ups/applications/10002/supplemental"
+                                              onClick={[Function]}
+                                            >
+                                              Application Name 2
+                                            </a>
+                                          </LinkAnchor>
+                                        </Link>
                                       </Cell>
                                     </div>
                                   </TdComponent>
@@ -9153,12 +9177,24 @@ exports[`LeaseUpApplicationsPage should match the snapshot 1`] = `
                                         viewIndex={2}
                                         width={100}
                                       >
-                                        <a
+                                        <Link
                                           className="has-border"
-                                          href="/lease-ups/applications/10003/supplemental"
+                                          to="/lease-ups/applications/10003/supplemental"
                                         >
-                                          Application Name 3
-                                        </a>
+                                          <LinkAnchor
+                                            className="has-border"
+                                            href="/lease-ups/applications/10003/supplemental"
+                                            navigate={[Function]}
+                                          >
+                                            <a
+                                              className="has-border"
+                                              href="/lease-ups/applications/10003/supplemental"
+                                              onClick={[Function]}
+                                            >
+                                              Application Name 3
+                                            </a>
+                                          </LinkAnchor>
+                                        </Link>
                                       </Cell>
                                     </div>
                                   </TdComponent>
@@ -12530,12 +12566,24 @@ exports[`LeaseUpApplicationsPage should match the snapshot 1`] = `
                                         viewIndex={3}
                                         width={100}
                                       >
-                                        <a
+                                        <Link
                                           className="has-border"
-                                          href="/lease-ups/applications/10004/supplemental"
+                                          to="/lease-ups/applications/10004/supplemental"
                                         >
-                                          Application Name 4
-                                        </a>
+                                          <LinkAnchor
+                                            className="has-border"
+                                            href="/lease-ups/applications/10004/supplemental"
+                                            navigate={[Function]}
+                                          >
+                                            <a
+                                              className="has-border"
+                                              href="/lease-ups/applications/10004/supplemental"
+                                              onClick={[Function]}
+                                            >
+                                              Application Name 4
+                                            </a>
+                                          </LinkAnchor>
+                                        </Link>
                                       </Cell>
                                     </div>
                                   </TdComponent>
@@ -15907,12 +15955,24 @@ exports[`LeaseUpApplicationsPage should match the snapshot 1`] = `
                                         viewIndex={4}
                                         width={100}
                                       >
-                                        <a
+                                        <Link
                                           className="has-border"
-                                          href="/lease-ups/applications/10005/supplemental"
+                                          to="/lease-ups/applications/10005/supplemental"
                                         >
-                                          Application Name 5
-                                        </a>
+                                          <LinkAnchor
+                                            className="has-border"
+                                            href="/lease-ups/applications/10005/supplemental"
+                                            navigate={[Function]}
+                                          >
+                                            <a
+                                              className="has-border"
+                                              href="/lease-ups/applications/10005/supplemental"
+                                              onClick={[Function]}
+                                            >
+                                              Application Name 5
+                                            </a>
+                                          </LinkAnchor>
+                                        </Link>
                                       </Cell>
                                     </div>
                                   </TdComponent>

--- a/spec/javascript/components/supplemental_application/sections/RentalAssistance.test.js
+++ b/spec/javascript/components/supplemental_application/sections/RentalAssistance.test.js
@@ -4,12 +4,9 @@ import RentalAssistance, {
   RentalAssistanceForm,
   RentalAssistanceTable
 } from '~/components/supplemental_application/sections/RentalAssistance'
-import {
-  withForm,
-  shallowWithFormAndContext,
-  findByNameAndProps
-} from '../../../testUtils/wrapperUtil'
-import { InputField } from '~/utils/form/final_form/Field'
+import { withForm, shallowWithFormAndContext, findWithProps } from '../../../testUtils/wrapperUtil'
+import { InputField, SelectField } from '~/utils/form/final_form/Field'
+import Button from '~/components/atoms/Button'
 import ExpandableTable from '~/components/molecules/ExpandableTable'
 
 const baseContext = {
@@ -51,7 +48,7 @@ describe('RentalAssistance', () => {
   test('should render the Add Rental Assistance button by default', () => {
     const context = cloneDeep(baseContext)
     const wrapper = getWrapper(context)
-    expect(findByNameAndProps(wrapper, 'Button', { text: 'Add Rental Assistance' })).toHaveLength(1)
+    expect(findWithProps(wrapper, Button, { text: 'Add Rental Assistance' })).toHaveLength(1)
   })
 
   test('does not render the create new assistance form by default', () => {
@@ -65,7 +62,7 @@ describe('RentalAssistance', () => {
 
     beforeEach(() => {
       wrapper = getWrapper(cloneDeep(baseContext))
-      findByNameAndProps(wrapper, 'Button', { text: 'Add Rental Assistance' }).simulate('click')
+      findWithProps(wrapper, Button, { text: 'Add Rental Assistance' }).simulate('click')
     })
 
     test('should render the new rental assistance form after the add rental assistance button is clicked', () => {
@@ -75,9 +72,7 @@ describe('RentalAssistance', () => {
     test('should hide the new rental assistance form after cancel is clicked', () => {
       wrapper.find(RentalAssistanceForm).prop('onClose')()
       expect(wrapper.find(RentalAssistanceForm)).toHaveLength(0)
-      expect(findByNameAndProps(wrapper, 'Button', { text: 'Add Rental Assistance' })).toHaveLength(
-        1
-      )
+      expect(findWithProps(wrapper, Button, { text: 'Add Rental Assistance' })).toHaveLength(1)
     })
   })
 })
@@ -166,7 +161,7 @@ describe('RentalAssistanceForm', () => {
     // need to mount it to access the error classes
     const wrapper = getWrapper({ assistance: null, shouldMount: true })
 
-    findByNameAndProps(wrapper, 'Button', { text: 'Save' }).simulate('click')
+    findWithProps(wrapper, Button, { text: 'Save' }).simulate('click')
     expect(wrapper.find('.rental-assistance-type.error').exists()).toBeTruthy()
   })
 
@@ -182,11 +177,11 @@ describe('RentalAssistanceForm', () => {
         loading: false
       })
 
-      saveButtonWrapper = findByNameAndProps(wrapper, 'Button', { id: 'rental-assistance-save' })
-      cancelButtonWrapper = findByNameAndProps(wrapper, 'Button', {
+      saveButtonWrapper = findWithProps(wrapper, Button, { id: 'rental-assistance-save' })
+      cancelButtonWrapper = findWithProps(wrapper, Button, {
         id: 'rental-assistance-cancel'
       })
-      deleteButtonWrapper = findByNameAndProps(wrapper, 'Button', {
+      deleteButtonWrapper = findWithProps(wrapper, Button, {
         id: 'rental-assistance-delete'
       })
     })
@@ -214,11 +209,11 @@ describe('RentalAssistanceForm', () => {
         loading: true
       })
 
-      saveButtonWrapper = findByNameAndProps(wrapper, 'Button', { id: 'rental-assistance-save' })
-      cancelButtonWrapper = findByNameAndProps(wrapper, 'Button', {
+      saveButtonWrapper = findWithProps(wrapper, Button, { id: 'rental-assistance-save' })
+      cancelButtonWrapper = findWithProps(wrapper, Button, {
         id: 'rental-assistance-cancel'
       })
-      deleteButtonWrapper = findByNameAndProps(wrapper, 'Button', {
+      deleteButtonWrapper = findWithProps(wrapper, Button, {
         id: 'rental-assistance-delete'
       })
     })
@@ -263,19 +258,18 @@ describe('RentalAssistanceForm', () => {
     })
 
     test('should not render the delete button', () => {
-      expect(findByNameAndProps(wrapper, 'Button', { text: 'Delete' })).toHaveLength(0)
+      expect(findWithProps(wrapper, Button, { text: 'Delete' })).toHaveLength(0)
     })
 
     test('should call the save callback when clicked', () => {
-      findByNameAndProps(wrapper, 'SelectField', { label: 'Type of Assistance' }).simulate(
-        'change',
-        { target: { value: 'Catholic Charities' } }
-      )
+      findWithProps(wrapper, SelectField, { label: 'Type of Assistance' }).simulate('change', {
+        target: { value: 'Catholic Charities' }
+      })
 
       expect(mockSaveCallback.mock.calls).toHaveLength(0)
       expect(mockCloseCallback.mock.calls).toHaveLength(0)
       expect(mockDeleteCallback.mock.calls).toHaveLength(0)
-      findByNameAndProps(wrapper, 'Button', { text: 'Save' }).simulate('click')
+      findWithProps(wrapper, Button, { text: 'Save' }).simulate('click')
       expect(mockSaveCallback.mock.calls).toHaveLength(1)
       expect(mockCloseCallback.mock.calls).toHaveLength(0)
       expect(mockDeleteCallback.mock.calls).toHaveLength(0)
@@ -285,7 +279,7 @@ describe('RentalAssistanceForm', () => {
       expect(mockSaveCallback.mock.calls).toHaveLength(0)
       expect(mockCloseCallback.mock.calls).toHaveLength(0)
       expect(mockDeleteCallback.mock.calls).toHaveLength(0)
-      findByNameAndProps(wrapper, 'Button', { text: 'Cancel' }).simulate('click')
+      findWithProps(wrapper, Button, { text: 'Cancel' }).simulate('click')
       expect(mockSaveCallback.mock.calls).toHaveLength(0)
       expect(mockCloseCallback.mock.calls).toHaveLength(1)
       expect(mockDeleteCallback.mock.calls).toHaveLength(0)
@@ -320,19 +314,18 @@ describe('RentalAssistanceForm', () => {
     })
 
     test('should render the delete button', () => {
-      expect(findByNameAndProps(wrapper, 'Button', { text: 'Delete' })).toHaveLength(1)
+      expect(findWithProps(wrapper, Button, { text: 'Delete' })).toHaveLength(1)
     })
 
     test('should call the save callback when clicked', () => {
-      findByNameAndProps(wrapper, 'SelectField', { label: 'Type of Assistance' }).simulate(
-        'change',
-        { target: { value: 'Catholic Charities' } }
-      )
+      findWithProps(wrapper, SelectField, { label: 'Type of Assistance' }).simulate('change', {
+        target: { value: 'Catholic Charities' }
+      })
 
       expect(mockSaveCallback.mock.calls).toHaveLength(0)
       expect(mockCloseCallback.mock.calls).toHaveLength(0)
       expect(mockDeleteCallback.mock.calls).toHaveLength(0)
-      findByNameAndProps(wrapper, 'Button', { text: 'Save' }).simulate('click')
+      findWithProps(wrapper, Button, { text: 'Save' }).simulate('click')
       expect(mockSaveCallback.mock.calls).toHaveLength(1)
       expect(mockCloseCallback.mock.calls).toHaveLength(0)
       expect(mockDeleteCallback.mock.calls).toHaveLength(0)
@@ -342,7 +335,7 @@ describe('RentalAssistanceForm', () => {
       expect(mockSaveCallback.mock.calls).toHaveLength(0)
       expect(mockCloseCallback.mock.calls).toHaveLength(0)
       expect(mockDeleteCallback.mock.calls).toHaveLength(0)
-      findByNameAndProps(wrapper, 'Button', { text: 'Delete' }).simulate('click')
+      findWithProps(wrapper, Button, { text: 'Delete' }).simulate('click')
       expect(mockSaveCallback.mock.calls).toHaveLength(0)
       expect(mockCloseCallback.mock.calls).toHaveLength(0)
       expect(mockDeleteCallback.mock.calls).toHaveLength(1)
@@ -352,7 +345,7 @@ describe('RentalAssistanceForm', () => {
       expect(mockSaveCallback.mock.calls).toHaveLength(0)
       expect(mockCloseCallback.mock.calls).toHaveLength(0)
       expect(mockDeleteCallback.mock.calls).toHaveLength(0)
-      findByNameAndProps(wrapper, 'Button', { text: 'Cancel' }).simulate('click')
+      findWithProps(wrapper, Button, { text: 'Cancel' }).simulate('click')
       expect(mockSaveCallback.mock.calls).toHaveLength(0)
       expect(mockCloseCallback.mock.calls).toHaveLength(1)
       expect(mockDeleteCallback.mock.calls).toHaveLength(0)

--- a/spec/javascript/testUtils/wrapperUtil.js
+++ b/spec/javascript/testUtils/wrapperUtil.js
@@ -64,15 +64,20 @@ export const shallowWithFormAndContext = (context, formToChildrenFunc) => {
   return diveThroughContextWrappers(diveThroughFormWrappers(formWrapper))
 }
 
-export const findByNameAndProps = (wrapper, name, props) => {
+const nameOrTypeMatches = (node, nodeNameOrType) =>
+  typeof nodeNameOrType === 'string'
+    ? node.name() === nodeNameOrType
+    : node.type() === nodeNameOrType
+
+export const findByNameAndProps = (wrapper, nodeNameOrType, props) => {
   const predicate = (n) =>
-    n.name() === name && Object.keys(props).every((k) => n.prop(k) === props[k])
+    nameOrTypeMatches(n, nodeNameOrType) && Object.keys(props).every((k) => n.prop(k) === props[k])
 
   return wrapper.findWhere(predicate)
 }
 
-export const findWithText = (wrapper, nodeName, text) => {
-  const predicate = (n) => n.name() === nodeName && n.text() === text
+export const findWithText = (wrapper, nodeNameOrType, text) => {
+  const predicate = (n) => nameOrTypeMatches(n, nodeNameOrType) && n.text() === text
   return wrapper.findWhere(predicate)
 }
 

--- a/spec/javascript/testUtils/wrapperUtil.js
+++ b/spec/javascript/testUtils/wrapperUtil.js
@@ -69,13 +69,32 @@ const nameOrTypeMatches = (node, nodeNameOrType) =>
     ? node.name() === nodeNameOrType
     : node.type() === nodeNameOrType
 
-export const findByNameAndProps = (wrapper, nodeNameOrType, props) => {
+/**
+ * Find the child or children that have the given name and props.
+ *
+ * @param {*} wrapper the enzyme wrapper to search through (can be shallow or mounted)
+ * @param {*} nodeNameOrType either a string node name or a component constructor function. Ex. any
+ *                           of the following will work: ['RentalAssistance', RentalAssistance,
+ *                           'a', 'button']. Note that complicated selectors do not work, eg. 'button#button_id'
+ * @param {*} props The props to check equality for. These do not have to be exhaustive, we only check the props
+ *                  that are provided.
+ */
+export const findWithProps = (wrapper, nodeNameOrType, props) => {
   const predicate = (n) =>
     nameOrTypeMatches(n, nodeNameOrType) && Object.keys(props).every((k) => n.prop(k) === props[k])
 
   return wrapper.findWhere(predicate)
 }
 
+/**
+ * Find the child or children that have the given name and text representation.
+ *
+ * @param {*} wrapper the enzyme wrapper to search through (can be shallow or mounted)
+ * @param {*} nodeNameOrType either a string node name or a component constructor function. Ex. any
+ *                           of the following will work: ['RentalAssistance', RentalAssistance,
+ *                           'a', 'button']. Note that complicated selectors do not work, eg. 'button#button_id'
+ * @param {*} text The exact text the child has.
+ */
 export const findWithText = (wrapper, nodeNameOrType, text) => {
   const predicate = (n) => nameOrTypeMatches(n, nodeNameOrType) && n.text() === text
   return wrapper.findWhere(predicate)


### PR DESCRIPTION
Followup for [DAH-42]

During testing I realized that the application table links weren't using react routing. This PR changes that.

This PR:
- Adds routing to application table links
- Makes the leaseup breadcrumb on the application table shows as a link even during loading phase
- updates wrapperUtil to allow react type selectors to be passed in, not just string names.



<img width="430" alt="- 2020-10-26 at 11 37 53 AM" src="https://user-images.githubusercontent.com/64036574/97214034-b3d07280-177f-11eb-9742-2771ea456d0f.png">


[DAH-42]: https://sfgovdt.jira.com/browse/DAH-42