### PR TITLE
[Hotfix] Fix link on export button [DAH-600]

### DIFF
--- a/app/javascript/components/lease_ups/LeaseUpApplicationsPage.js
+++ b/app/javascript/components/lease_ups/LeaseUpApplicationsPage.js
@@ -15,13 +15,13 @@ import Context from './context'
 import { SALESFORCE_DATE_FORMAT } from '~/utils/utils'
 
 const ROWS_PER_PAGE = 20
-const BASE_URL = typeof SALESFORCE_BASE_URL !== 'undefined' ? SALESFORCE_BASE_URL : ''
 
 const getPageHeaderData = (listing) => {
+  const baseUrl = typeof SALESFORCE_BASE_URL !== 'undefined' ? SALESFORCE_BASE_URL : ''
   const exportButtonAction = listing?.report_id
     ? {
         title: 'Export',
-        link: `${BASE_URL}/${listing?.report_id}?csv=1`
+        link: `${baseUrl}/${listing?.report_id}?csv=1`
       }
     : null
 


### PR DESCRIPTION
[DAH-600]

[TKT-06243](https://sfhousing.lightning.force.com/lightning/r/Ticket_Management__c/a224U000015vqqTQAQ/view) 
Turns out the way we assigned BASE_URL wasn't working because the `SALESFORCE_BASE_URL` isn't initialized when the file is loaded. Moving it into the render function fixes this issue.

Hopefully larry can review this on monday since Andrea will be out

[DAH-600]: https://sfgovdt.jira.com/browse/DAH-600