### PR TITLE
Fix live work selects on tab change [DAH-531]

### DIFF
--- a/app/javascript/components/supplemental_application/sections/preferences/LiveOrWorkInSanFranciscoPanel.js
+++ b/app/javascript/components/supplemental_application/sections/preferences/LiveOrWorkInSanFranciscoPanel.js
@@ -28,8 +28,12 @@ const LiveOrWorkInSanFranciscoPanel = ({
   preferenceIndex,
   applicationMembersOptions
 }) => {
+  const getFormPreferenceOrNull = () => form.getState().values?.preferences?.[preferenceIndex]
+
   const [prefProofTypeOptions, setProofTypeOptions] = useState(
-    getLWPrefProofTypeOptions(preference.individual_preference)
+    getLWPrefProofTypeOptions(
+      getFormPreferenceOrNull()?.individual_preference ?? preference.individual_preference
+    )
   )
 
   const updatePrefProofOptions = (event) => {


### PR DESCRIPTION
[DAH-531]

Problem #1: In app-00271364 I make a change to the work preference ( I don’t click save), I click the Short Form App tab, I click the Supp App tab, and everything persists except the Type of Proof Field, which goes back to Select One. 

Problem #2: Even with Live in SF selected the dropdown for Type of Proof shows the work options (paystub, letter) and I need to cancel out to get the correct Live in SF options to show up in the Type of Proof dropdown.  

[DAH-531]: https://sfgovdt.jira.com/browse/DAH-531