### PR TITLE
[Hotfix][Partners] Bump mimemagic gem [DAH-752]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,10 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+# Rails depends on 0.3.5, this has since been taken down (as of 3/24/2021),
+# so we have to force 0.3.8
+gem 'mimemagic', '~> 0.3.8'
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.4'
 # Set a minimum version for Rack to avoid security vulnerability in Rack <2.2.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,8 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.4)
+    mimemagic (0.3.8)
+      nokogiri (~> 1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
@@ -363,6 +364,7 @@ DEPENDENCIES
   hashie (~> 3.5)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  mimemagic (~> 0.3.8)
   newrelic_rpm
   oj
   omniauth-rails_csrf_protection


### PR DESCRIPTION
Webapp ticket: [DAH-751]
Partners ticket: [DAH-752]

Webapp currently relies on mimemagic 3.5, which has been removed from the gem repository for licensing reasons. This bumps it to 3.8, which still exists.

We want to hold off on deploying this change until we're sure this is the correct solution, as the situation is still developing. 

See these issues [new mimemagic version released under MIT](https://github.com/rails/rails/issues/41757), [dependency on mimemagic no longer valid](https://github.com/rails/rails/issues/41750) for more info

[DAH-751]: https://sfgovdt.jira.com/browse/DAH-751
[DAH-752]: https://sfgovdt.jira.com/browse/DAH-752