### PR TITLE
Fix missing AMI chart type in Salesforce DAH-824

### DIFF
--- a/app/javascript/components/applications/application_form/formOptions.js
+++ b/app/javascript/components/applications/application_form/formOptions.js
@@ -2,11 +2,10 @@ import { isEmpty } from 'lodash'
 
 const isNullOrEmptyString = (value) => value === undefined || value === null || value === ''
 
-const labelize = (options, attrs = {}, noPlaceholder = false) => {
+const labelize = (options, attrs = {}) => {
   if (isEmpty(options)) return []
 
   const emptyInitialOptionPresent =
-    noPlaceholder ||
     isEmpty(options) ||
     options[0] === '' ||
     (Object.prototype.hasOwnProperty.call(options[0], 'value') &&

--- a/app/javascript/components/supplemental_application/sections/ConfirmedHouseholdIncome.js
+++ b/app/javascript/components/supplemental_application/sections/ConfirmedHouseholdIncome.js
@@ -132,7 +132,6 @@ const ConfirmedHouseholdIncome = ({
               fieldName='ami_chart_type'
               label='AMI Chart Type'
               options={amiChartTypes}
-              noPlaceholder={amiChartTypes.length <= 1}
             />
           </FormGrid.Item>
         </FormGrid.Row>
@@ -143,7 +142,6 @@ const ConfirmedHouseholdIncome = ({
               fieldName='ami_chart_year'
               label='AMI Chart Year'
               options={amiChartYears}
-              noPlaceholder={amiChartYears.length <= 1}
             />
           </FormGrid.Item>
         </FormGrid.Row>

--- a/app/javascript/utils/form/final_form/Field.js
+++ b/app/javascript/utils/form/final_form/Field.js
@@ -187,7 +187,6 @@ export const SelectField = ({
   disabled = false,
   disabledOptions,
   selectValue,
-  noPlaceholder,
   format,
   isDirty = true,
   helpText
@@ -201,8 +200,7 @@ export const SelectField = ({
     formatOnBlur={isDirty}
   >
     {({ input, meta }) => {
-      const selectOptions =
-        disabled && disabledOptions ? disabledOptions : labelize(options, {}, noPlaceholder)
+      const selectOptions = disabled && disabledOptions ? disabledOptions : labelize(options, {})
       return (
         <>
           <div className={classNames('form-group', { error: meta.error && meta.touched })}>

--- a/spec/javascript/components/applications/application_form/formOptions.test.js
+++ b/spec/javascript/components/applications/application_form/formOptions.test.js
@@ -34,19 +34,15 @@ describe('labelize', () => {
       const option = ''
       expect(labelize([option])[0]).toEqual({ value: '', label: '' })
     })
-    test('does not add an empty option with noPlaceholder=true', () => {
-      const option = { value: 'test', label: 'test' }
-      expect(labelize([option], {}, true)[0]).toEqual(option)
-    })
   })
   describe('when all or part of an option is null', () => {
     test('it keeps label as null', () => {
       const option = { value: 'test', label: null }
-      expect(labelize([option], {}, true)[0]).toEqual(option)
+      expect(labelize([option], {})[1]).toEqual(option)
     })
     test('it keeps value as null', () => {
       const option = { value: null, label: 'label' }
-      expect(labelize([option], {}, true)[0]).toEqual(option)
+      expect(labelize([option], {})[0]).toEqual(option)
     })
   })
 })

--- a/spec/javascript/components/supplemental_application/sections/__snapshots__/ConfirmedHousholdIncome.test.js.snap
+++ b/spec/javascript/components/supplemental_application/sections/__snapshots__/ConfirmedHousholdIncome.test.js.snap
@@ -88,7 +88,6 @@ exports[`ConfirmedHouseholdIncome it matches snapshot when all values are empty 
           fieldName="ami_chart_type"
           id="ami_chart_type"
           label="AMI Chart Type"
-          noPlaceholder={true}
           options={Array []}
         />
       </Component>
@@ -101,7 +100,6 @@ exports[`ConfirmedHouseholdIncome it matches snapshot when all values are empty 
           fieldName="ami_chart_year"
           id="ami_chart_year"
           label="AMI Chart Year"
-          noPlaceholder={true}
           options={Array []}
         />
       </Component>

--- a/spec/javascript/e2e/SupplementalApplicationPage/confirmed_household.e2e.js
+++ b/spec/javascript/e2e/SupplementalApplicationPage/confirmed_household.e2e.js
@@ -35,8 +35,10 @@ describe('SupplementalApplicationPage confirmed household income section', () =>
       await sharedSteps.enterValue(page, confirmedAnnualSelector, confirmedAnnualValue.currency)
       await sharedSteps.enterValue(page, finalHHAnnualSelector, finalHHAnnualValue.currency)
 
-      // Enter AMI Percentage
+      // Enter AMI Info
       await sharedSteps.enterValue(page, amiPercentageSelector, '5.55')
+      await page.select(amiChartTypeSelector, 'HUD Unadjusted')
+      await page.select(amiChartYearSelector, '2018')
 
       // Click save
       await supplementalApplicationSteps.savePage(page)


### PR DESCRIPTION
DAH-824

AMI Chart type was missing in Salesforce because we were choosing not to allow for a placeholder "Select One..." in the dropdown. This led to the value not saving to Salesforce. I removed the option because it seemed like it's better to have the leasing agent actively choose the value so that it's not filled out when the leasing agent is working on earlier pieces of the application. 

Review instrux in the ticket. 