### PR TITLE
Update snapshot to include 2022 as an option for AMI chart year

### DIFF
--- a/spec/javascript/components/supplemental_application/__snapshots__/SupplementalApplicationPage.test.js.snap
+++ b/spec/javascript/components/supplemental_application/__snapshots__/SupplementalApplicationPage.test.js.snap
@@ -1696,6 +1696,11 @@ Array [
                         >
                           2021
                         </option>
+                        <option
+                          value={2022}
+                        >
+                          2022
+                        </option>
                       </select>
                     </div>
                   </div>


### PR DESCRIPTION
Our AMI dropdown is based on the current year, so the change to the new year caused unit tests to start failing on main. 