### PR TITLE
DAH-1321 cleanup filtering for units and leases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ TAGS
 .vscode/*
 !.vscode-default/*
 .idea/*
+*.iml

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.7.1'
+ruby '2.7.0'
 
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.7.0'
+ruby '2.7.1'
 
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.7.7'
+ruby '2.7.0'
 
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.7.0'
+ruby '2.7.7'
 
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?("/")
@@ -33,6 +33,7 @@ gem 'jbuilder', '~> 2.5'
 # gem 'capistrano-rails', group: :development
 
 gem 'newrelic_rpm'
+gem 'mini_portile2', '~> 2.5', '>= 2.5.1'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -400,7 +400,7 @@ DEPENDENCIES
   webpacker-react (~> 0.3.2)
 
 RUBY VERSION
-   ruby 2.7.1p83
+   ruby 2.7.0p0
 
 BUNDLED WITH
-   2.1.4
+   2.1.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -401,7 +401,7 @@ DEPENDENCIES
   webpacker-react (~> 0.3.2)
 
 RUBY VERSION
-   ruby 2.7.7p221
+   ruby 2.7.0p0
 
 BUNDLED WITH
    2.1.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -400,7 +400,7 @@ DEPENDENCIES
   webpacker-react (~> 0.3.2)
 
 RUBY VERSION
-   ruby 2.7.0p0
+   ruby 2.7.1p83
 
 BUNDLED WITH
-   2.1.2
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,6 +364,7 @@ DEPENDENCIES
   hashie (~> 3.5)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  mini_portile2 (~> 2.5, >= 2.5.1)
   newrelic_rpm
   oj
   omniauth-rails_csrf_protection
@@ -400,7 +401,7 @@ DEPENDENCIES
   webpacker-react (~> 0.3.2)
 
 RUBY VERSION
-   ruby 2.7.0p0
+   ruby 2.7.7p221
 
 BUNDLED WITH
    2.1.2

--- a/app/javascript/components/supplemental_application/sections/Lease.js
+++ b/app/javascript/components/supplemental_application/sections/Lease.js
@@ -153,10 +153,11 @@ const Lease = ({ form, values }) => {
    *  - if there are leases, they cannot be in draft or signed status
    *  - if the unit has an application, it must match the current one
    */
+  const unavailableStatuses = ['Draft', 'Signed']
   const availableUnits = state.units.filter(
     (unit) =>
       !Array.isArray(unit.leases) ||
-      !unit.leases.some((lease) => ['Draft', 'Signed'].includes(lease.lease_status)) ||
+      !unit.leases.some((lease) => unavailableStatuses.includes(lease.lease_status)) ||
       unit.leases.some((lease) => lease.application_id === state.application.id)
   )
 

--- a/app/javascript/components/supplemental_application/sections/Lease.js
+++ b/app/javascript/components/supplemental_application/sections/Lease.js
@@ -147,11 +147,17 @@ const Lease = ({ form, values }) => {
     ...map(confirmedPreferences, pluck('id', 'preference_name'))
   ])
 
+  /**
+   * available units fit the following criteria
+   *  - if it doesn't have any leases
+   *  - if there are leases, they cannot be in draft or signed status
+   *  - if the unit has an application, it must match the current one
+   */
   const availableUnits = state.units.filter(
     (unit) =>
-      !unit.application_id ||
-      unit.application_id === state.application.id ||
-      (unit.application_id && unit.lease_status === 'Ended')
+      !Array.isArray(unit.leases) ||
+      !unit.leases.some((lease) => ['Draft', 'Signed'].includes(lease.lease_status)) ||
+      unit.leases.some((lease) => lease.application_id === state.application.id)
   )
 
   const availableUnitsOptions = formUtils.toOptions(
@@ -169,10 +175,18 @@ const Lease = ({ form, values }) => {
     return prefUsed?.preference_name === pref
   }
 
+  /**
+   * Checks if a given unit is using the same preference as the provided preference
+   * @param unit
+   * @param pref
+   * @return {false|*} returns true if the unit is used with the same preference on a different application
+   */
   const unitIsUsedWithPrefElsewhere = (unit, pref) =>
-    unit.application_id &&
-    unit.application_id !== state.application.id &&
-    unit.preference_used_name === pref
+    Array.isArray(unit.leases) &&
+    unit.leases.some(
+      (lease) =>
+        lease.application_id !== state.application.id && pref === lease.preference_used_name
+    )
 
   const numUnitsUsingPref = (pref) =>
     state.units.filter(

--- a/app/models/force/unit.rb
+++ b/app/models/force/unit.rb
@@ -18,6 +18,7 @@ module Force
       { domain: 'max_ami_for_qualifying_unit', salesforce: 'Max_AMI_for_Qualifying_Unit' },
       { domain: 'reserved_type', salesforce: 'Reserved_Type' },
       { domain: 'priority_type', salesforce: 'Priority_Type' },
+      { domain: 'leases', salesforce: 'Leases' }
     ].freeze
   end
 end

--- a/app/services/force/units_service.rb
+++ b/app/services/force/units_service.rb
@@ -8,9 +8,8 @@ module Force
     FIELDS = load_fields(FIELD_NAME).freeze
 
     # Returns units and relevant lease information for specified listing.
-    # Units contain info about unit number + eligibility. We merge
-    # this with Lease info about which application is assigned to a unit and
-    # what preference was used.
+    # Units contain info about unit number + eligibility. We join
+    # this with info from Leases
     def units_and_leases_for_listing(listing_id)
       lease_query = builder.from(:Leases__r)
                          .select('Application__c, Lease_Status__c, Preference_Used_Name__c')
@@ -23,12 +22,15 @@ module Force
              .query
              .records
 
+      #format/convert unit and lease objects
       domain_units = result.map do |unit|
-        # Flatten lease fields and merge with unit fields
-        lease = unit['Leases'] ? unit['Leases'][0] : nil
-        domain_lease_fields = Force::Lease.from_salesforce(lease).to_domain if lease
         domain_unit = Force::Unit.from_salesforce(unit).to_domain
-        domain_unit.merge(domain_lease_fields || {})
+        if domain_unit['leases']
+          domain_unit['leases'] = domain_unit['leases']
+                                    .filter do |lease| true if lease end
+                                    .map do |lease| Force::Lease.from_salesforce(lease).to_domain end
+        end
+        domain_unit
       end
       domain_units
     end

--- a/app/services/force/units_service.rb
+++ b/app/services/force/units_service.rb
@@ -27,8 +27,8 @@ module Force
         domain_unit = Force::Unit.from_salesforce(unit).to_domain
         if domain_unit['leases']
           domain_unit['leases'] = domain_unit['leases']
-                                    .filter do |lease| true if lease end
-                                    .map do |lease| Force::Lease.from_salesforce(lease).to_domain end
+                                    .filter { |lease| true if lease }
+                                    .map { |lease| Force::Lease.from_salesforce(lease).to_domain }
         end
         domain_unit
       end

--- a/spec/javascript/components/supplemental_application/SupplementalApplicationPage.test.js
+++ b/spec/javascript/components/supplemental_application/SupplementalApplicationPage.test.js
@@ -89,7 +89,13 @@ jest.mock('apiService', () => {
         unit_type: 'studio',
         priority_type: null,
         max_ami_for_qualifying_unit: 50,
-        application_id: 'other application'
+        leases: [
+          {
+            application_id: 'testId',
+            preference_used_name: '',
+            lease_status: 'Signed'
+          }
+        ]
       })
 
       return listingId === _ID_NO_AVAILABLE_UNITS

--- a/spec/services/force/unit_service_spec.rb
+++ b/spec/services/force/unit_service_spec.rb
@@ -24,14 +24,18 @@ RSpec.describe Force::UnitsService do
       unit_number
       unit_type
       ami_chart_year
+      leases
     ]
 
     it 'should return lease fields when there is a lease on the unit' do
       VCR.use_cassette('services/force/unit_service/with_lease') do
         units = subject.units_and_leases_for_listing(LEASE_UP_LISTING_ID)
 
-        (expected_lease_keys + expected_unit_keys).each do |key|
+        (expected_unit_keys).each do |key|
           expect(units.first).to have_key(key)
+        end
+        (expected_lease_keys).each do |key|
+          expect(units.first.leases.first).to have_key(key)
         end
       end
     end


### PR DESCRIPTION
[DAH-1321](https://sfgovdt.jira.com/browse/DAH-1321)

-Rather than flattening the first lease object into the unit object, return an array of leases related to the unit.
-On the supplemental application page, filter the available units to not include any units that have a lease in draft or signed status