### PR TITLE
fix: DAH-2247 move test variables into cypress config

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -24,7 +24,20 @@ module.exports = defineConfig({
       LENDING_INSTITUTION: process.env.E2E_LENDING_INSTITUTION || 'Chase',
       LENDING_AGENT_ID: process.env.E2E_LENDING_AGENT_ID || '0030P00002NI63uQAD',
       COMMUNITY_LOGIN_URL: process.env.COMMUNITY_LOGIN_URL,
-
+      // Default to Automated Test Listing on Full
+      NON_LEASE_UP_LISTING_ID: process.env.E2E_NON_LEASE_UP_LISTING_ID || 'a0W0P00000F8YG4UAN',
+      // Default to Yellow Acres on Full
+      LEASE_UP_LISTING_ID: process.env.E2E_LEASE_UP_LISTING_ID || 'a0W0P00000GbyuQ',
+      // Default to an application from Yellow Acres on Full
+      LEASE_UP_LISTING_APPLICATION_ID:
+        process.env.E2E_LEASE_UP_LISTING_APPLICATION_ID || 'a0o0P00000GZazOQAT',
+      FIRST_ROW_LEASE_UP_APP_ID: process.env.FIRST_ROW_LEASE_UP_APP_ID || 'a0o0P00000IvWgcQAF',
+      SECOND_ROW_LEASE_UP_APP_ID: process.env.SECOND_ROW_LEASE_UP_APP_ID || 'a0o0P00000GZazsQAD',
+      THIRD_ROW_LEASE_UP_APP_ID: process.env.THIRD_ROW_LEASE_UP_APP_ID || 'a0o0P00000IvWgXQAV',
+      // Default to Sale Test Listing Homeownership Acres on Full
+      SALE_LISTING_ID: process.env.E2E_SALE_LISTING_ID || 'a0W0P00000GlKfBUAV',
+      // Default to sample flagged record set on full
+      FLAGGED_RECORD_SET_ID: process.env.E2E_FLAGGED_RECORD_SET_ID || 'a0r0P00002WqGZ6QAN',
       // When this is turned to true, Cypress will log the Salesforce password to the console
       // This is useful for debugging, but should never be turned on in a PR
       LOG_SECRETS: false

--- a/cypress/e2e/ApplicationEditPage.e2e.js
+++ b/cypress/e2e/ApplicationEditPage.e2e.js
@@ -1,4 +1,4 @@
-import { LEASE_UP_LISTING_APPLICATION_ID } from '../support/consts'
+const LEASE_UP_LISTING_APPLICATION_ID = Cypress.env('LEASE_UP_LISTING_APPLICATION_ID')
 
 describe('ApplicationEditPage', () => {
   it('should redirect edit application when lottery_status is anything other than "Not Yet Run"', () => {

--- a/cypress/e2e/ApplicationNewPage.e2e.js
+++ b/cypress/e2e/ApplicationNewPage.e2e.js
@@ -1,7 +1,4 @@
 import {
-  NON_LEASE_UP_LISTING_ID,
-  SALE_LISTING_ID,
-  LEASE_UP_LISTING_ID,
   FIRST_NAME,
   LAST_NAME,
   TRUNCATED_FIRST_NAME,
@@ -18,6 +15,10 @@ import {
   HOUSEHOLD_MEMBER_DOB_YEAR
 } from '../support/consts'
 import { usingFixtures } from '../support/utils'
+
+const NON_LEASE_UP_LISTING_ID = Cypress.env('NON_LEASE_UP_LISTING_ID')
+const LEASE_UP_LISTING_ID = Cypress.env('LEASE_UP_LISTING_ID')
+const SALE_LISTING_ID = Cypress.env('SALE_LISTING_ID')
 
 describe('ApplicationNewPage', () => {
   beforeEach(() => {

--- a/cypress/e2e/FlaggedApplicationsShowPage.e2e.js
+++ b/cypress/e2e/FlaggedApplicationsShowPage.e2e.js
@@ -1,9 +1,9 @@
-import { FLAGGED_RECORD_SET_ID } from '../support/consts'
 import { notSelectedOptionSelector, usingFixtures } from '../support/utils'
 
 const commentInputSelector = 'input[type="text"]'
 const openRowSelector = '.rt-expander.-open'
 const statusInputSelector = 'select'
+const FLAGGED_RECORD_SET_ID = Cypress.env('FLAGGED_RECORD_SET_ID')
 
 describe('FlaggedApplicationsShowPage', () => {
   beforeEach(() => {

--- a/cypress/e2e/LeaseUpApplicationsPage/status_update.e2e.js
+++ b/cypress/e2e/LeaseUpApplicationsPage/status_update.e2e.js
@@ -1,9 +1,4 @@
 import {
-  LEASE_UP_LISTING_ID,
-  SECOND_ROW_LEASE_UP_APP_ID,
-  THIRD_ROW_LEASE_UP_APP_ID
-} from '../../support/consts'
-import {
   bulkActionCheckboxId,
   statusMenuItemSelector,
   nthRowStatusDropdownSelector,
@@ -16,6 +11,9 @@ const unselectedStatusMenuItem = 'li[aria-selected="false"].dropdown-menu_item >
 const bulkStatusDropdown = '.filter-row .status-dropdown__control .dropdown-button'
 const PROCESSING = 'Processing'
 const APPEALED = 'Appealed'
+const LEASE_UP_LISTING_ID = Cypress.env('LEASE_UP_LISTING_ID')
+const SECOND_ROW_LEASE_UP_APP_ID = Cypress.env('SECOND_ROW_LEASE_UP_APP_ID')
+const THIRD_ROW_LEASE_UP_APP_ID = Cypress.env('THIRD_ROW_LEASE_UP_APP_ID')
 
 describe('LeaseUpApplicationsPage status update', () => {
   beforeEach(() => {

--- a/cypress/e2e/SupplementalApplicationPage/confirmed_household.e2e.js
+++ b/cypress/e2e/SupplementalApplicationPage/confirmed_household.e2e.js
@@ -1,4 +1,3 @@
-import { LEASE_UP_LISTING_APPLICATION_ID } from '../../support/consts'
 import { generateRandomCurrency, usingFixtures } from '../../support/utils'
 
 const hhAssetsSelector = '#form-household_assets'
@@ -8,6 +7,7 @@ const finalHHAnnualSelector = '#form-hh_total_income_with_assets_annual'
 const amiPercentageSelector = '#ami_percentage'
 const amiChartTypeSelector = '#ami_chart_type'
 const amiChartYearSelector = '#ami_chart_year'
+const LEASE_UP_LISTING_APPLICATION_ID = Cypress.env('LEASE_UP_LISTING_APPLICATION_ID')
 
 describe('SupplementalApplicationPage confirmed household income section', () => {
   beforeEach(() => {
@@ -37,12 +37,19 @@ describe('SupplementalApplicationPage confirmed household income section', () =>
     cy.get(confirmedAnnualSelector).clear().type(confirmedAnnualValue.currency)
     cy.get(finalHHAnnualSelector).clear().type(finalHHAnnualValue.currency)
 
-    console.log({ hhAssetsValue, hhImputedAssetsValue, confirmedAnnualValue, finalHHAnnualValue })
+    const chartType =
+      Cypress.env('salesforceInstanceUrl') === 'https://sfhousing--full.sandbox.my.salesforce.com'
+        ? 'HUD Unadjusted'
+        : 'HCD Unadjusted'
+    const chartYear =
+      Cypress.env('salesforceInstanceUrl') === 'https://sfhousing--full.sandbox.my.salesforce.com'
+        ? 'HCD Unadjusted'
+        : '2020'
 
     // Enter AMI Info
     cy.get(amiPercentageSelector).clear().type('5.55')
-    cy.get(amiChartTypeSelector).select('HUD Unadjusted')
-    cy.get(amiChartYearSelector).select('2018')
+    cy.get(amiChartTypeSelector).select(chartType)
+    cy.get(amiChartYearSelector).select(chartYear)
 
     // Click save
     cy.saveSupplementalApplication(usingFixtures())
@@ -62,7 +69,7 @@ describe('SupplementalApplicationPage confirmed household income section', () =>
       '$' + String(finalHHAnnualValue.float.toFixed(2))
     )
     cy.getInputValue(amiPercentageSelector).should('equal', '5.55%')
-    cy.getInputValue(amiChartTypeSelector).should('equal', 'HUD Unadjusted')
-    cy.getInputValue(amiChartYearSelector).should('equal', '2018')
+    cy.getInputValue(amiChartTypeSelector).should('equal', chartType)
+    cy.getInputValue(amiChartYearSelector).should('equal', chartYear)
   })
 })

--- a/cypress/e2e/SupplementalApplicationPage/confirmed_household.e2e.js
+++ b/cypress/e2e/SupplementalApplicationPage/confirmed_household.e2e.js
@@ -43,7 +43,7 @@ describe('SupplementalApplicationPage confirmed household income section', () =>
         : 'HCD Unadjusted'
     const chartYear =
       Cypress.env('salesforceInstanceUrl') === 'https://sfhousing--full.sandbox.my.salesforce.com'
-        ? 'HCD Unadjusted'
+        ? '2018'
         : '2020'
 
     // Enter AMI Info

--- a/cypress/e2e/SupplementalApplicationPage/lease_information.e2e.js
+++ b/cypress/e2e/SupplementalApplicationPage/lease_information.e2e.js
@@ -1,10 +1,10 @@
-import { LEASE_UP_LISTING_APPLICATION_ID } from '../../support/consts'
 import { generateRandomCurrency } from '../../support/utils'
 
 const rentSelector = '#form-lease\\.total_monthly_rent_without_parking'
 const parkingDropdownSelector = '#form-lease\\.bmr_parking_space_assigned'
 const parkingRentSelector = '#form-lease\\.monthly_parking_rent'
 const tenantContributionSelector = '#form-lease\\.monthly_tenant_contribution'
+const LEASE_UP_LISTING_APPLICATION_ID = Cypress.env('LEASE_UP_LISTING_APPLICATION_ID')
 
 describe('SupplementalApplicationPage lease section', () => {
   beforeEach(() => {

--- a/cypress/e2e/SupplementalApplicationPage/preference.e2e.js
+++ b/cypress/e2e/SupplementalApplicationPage/preference.e2e.js
@@ -1,10 +1,11 @@
-import { LEASE_UP_LISTING_APPLICATION_ID } from '../../support/consts'
 import {
   notSelectedOptionSelector,
   selectedOptionSelector,
   generateRandomCurrency,
   usingFixtures
 } from '../../support/utils'
+
+const LEASE_UP_LISTING_APPLICATION_ID = Cypress.env('LEASE_UP_LISTING_APPLICATION_ID')
 
 const setupSupplementalsIntercept = () => {
   if (usingFixtures()) {

--- a/cypress/e2e/SupplementalApplicationPage/rental_assistance.e2e.js
+++ b/cypress/e2e/SupplementalApplicationPage/rental_assistance.e2e.js
@@ -1,5 +1,6 @@
-import { LEASE_UP_LISTING_APPLICATION_ID } from '../../support/consts'
 import { generateRandomCurrency, usingFixtures } from '../../support/utils'
+
+const LEASE_UP_LISTING_APPLICATION_ID = Cypress.env('LEASE_UP_LISTING_APPLICATION_ID')
 
 describe('SupplementalApplicationPage Rental Assistance Information section', () => {
   beforeEach(() => {

--- a/cypress/e2e/SupplementalApplicationPage/short_form_tab.e2e.js
+++ b/cypress/e2e/SupplementalApplicationPage/short_form_tab.e2e.js
@@ -1,8 +1,8 @@
-import { LEASE_UP_LISTING_APPLICATION_ID } from '../../support/consts'
-
 const mobilitySelector = 'input#form-has_ada_priorities_selected\\.mobility_impairments'
 const shortFormTabSelector = '.tabs li:nth-child(2)'
 const supplementalTabSelector = '.tabs li:nth-child(1)'
+const LEASE_UP_LISTING_APPLICATION_ID = Cypress.env('LEASE_UP_LISTING_APPLICATION_ID')
+
 describe('SupplementalApplicationPage clicking on the short form tab', () => {
   beforeEach(() => {
     cy.setupIntercepts()

--- a/cypress/e2e/SupplementalApplicationPage/status_update.e2e.js
+++ b/cypress/e2e/SupplementalApplicationPage/status_update.e2e.js
@@ -1,6 +1,6 @@
-import { LEASE_UP_LISTING_APPLICATION_ID } from '../../support/consts'
 import { usingFixtures } from '../../support/utils'
 
+const LEASE_UP_LISTING_APPLICATION_ID = Cypress.env('LEASE_UP_LISTING_APPLICATION_ID')
 const unselectedStatusMenuItem = 'li[aria-selected="false"].dropdown-menu_item > a'
 
 describe('SupplementalApplicationPage statuses', () => {

--- a/cypress/support/consts.js
+++ b/cypress/support/consts.js
@@ -1,29 +1,6 @@
 require('dotenv').config()
 
-// Default to Automated Test Listing on Full
-export const NON_LEASE_UP_LISTING_ID =
-  process.env.E2E_NON_LEASE_UP_LISTING_ID || 'a0W0P00000F8YG4UAN'
-
-// Default to Yellow Acres on Full
-export const LEASE_UP_LISTING_ID = process.env.E2E_LEASE_UP_LISTING_ID || 'a0W0P00000GbyuQ'
-
-// Default to an application from Yellow Acres on Full
-export const LEASE_UP_LISTING_APPLICATION_ID =
-  process.env.E2E_LEASE_UP_LISTING_APPLICATION_ID || 'a0o0P00000GZazOQAT'
-export const FIRST_ROW_LEASE_UP_APP_ID =
-  process.env.FIRST_ROW_LEASE_UP_APP_ID || 'a0o0P00000IvWgcQAF'
-export const SECOND_ROW_LEASE_UP_APP_ID =
-  process.env.SECOND_ROW_LEASE_UP_APP_ID || 'a0o0P00000GZazsQAD'
-export const THIRD_ROW_LEASE_UP_APP_ID =
-  process.env.THIRD_ROW_LEASE_UP_APP_ID || 'a0o0P00000IvWgXQAV'
-
 export const DEFAULT_E2E_TIME_OUT = 240000 // 4 minutes
-
-// Default to Sale Test Listing Homeownership Acres on Full
-export const SALE_LISTING_ID = process.env.E2E_SALE_LISTING_ID || 'a0W0P00000GlKfBUAV'
-
-// Default to sample flagged record set on full
-export const FLAGGED_RECORD_SET_ID = process.env.E2E_FLAGGED_RECORD_SET_ID || 'a0r0P00002WqGZ6QAN'
 
 // Application Fields
 export const FIRST_NAME = 'E2ETEST-VERY_LONG_FIRST_NAME_THAT_IS_40!NOWOVER'


### PR DESCRIPTION
[DAH-2247](https://sfgovdt.jira.com/browse/DAH-2247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

The test variables weren't grabbing the env variables. I moved them into the cypress config so that we could use different env variables for QA e2e tests.

To review, use the env-partners-qa environment from sf-dahlia-credentials and run e2e tests locally to make sure they pass.

[DAH-2247]: https://sfgovdt.jira.com/browse/DAH-2247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ