### PR TITLE
DAH-2475 fix fcfs call

### DIFF
--- a/app/javascript/apiService.js
+++ b/app/javascript/apiService.js
@@ -1,4 +1,5 @@
 import { request } from 'api/request'
+import { LISTING_TYPE_FIRST_COME_FIRST_SERVED } from 'utils/consts'
 
 import { isLeaseAlreadyCreated } from './components/supplemental_application/utils/supplementalApplicationUtils'
 
@@ -77,10 +78,20 @@ const fetchApplications = async ({ page, filters }) =>
   )
 
 const fetchLeaseUpApplications = async (listingId, page, { filters }) => {
+  const generalApps = {
+    records: [],
+    pages: 0
+  }
+
   // Fetch application preferences associated with a lease up listing.
   const appPrefs = await getLeaseUpApplications(listingId, filters)
-  // Fetch general applications associated with a lease up listing.
-  const generalApps = await getLeaseUpApplications(listingId, filters, true)
+
+  if (appPrefs.listing_type !== LISTING_TYPE_FIRST_COME_FIRST_SERVED) {
+    // Fetch general applications associated with a lease up listing.
+    const generalAppsResponse = await getLeaseUpApplications(listingId, filters, true)
+    generalApps.records = generalAppsResponse.records
+    generalApps.pages = generalAppsResponse.pages
+  }
 
   return {
     records: [...appPrefs.records, ...generalApps.records],


### PR DESCRIPTION
DAH-2475

I noticed a bug in full after the original PR for this ticket got merged. FCFS listings don't have general applications, so it was just returning duplicate applications.

See https://dahlia-lap-full.herokuapp.com/lease-ups/listings/a0W6s000008C9TlEAK - it returns all the applicants twice
Compare to the pr app on the same lease up listing and it should only return all the applicants once.