### PR TITLE
chore: DAH-2563 updating create_release_branch

### DIFF
--- a/create_release_branch.sh
+++ b/create_release_branch.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# This creates a new release branch off of production, merges it with main,
-# and creates a new pull request for that branch.
+# This creates a new release branch off of main
 
 skip_branch_creation='false'
 
@@ -33,7 +32,6 @@ git checkout main && git pull --rebase origin main
 echo "Checking out new branch off main: $branch_name"
 git checkout -b $branch_name
 
-echo "Pushing branch to Github and opening the compare view in browser."
-
+echo "Pushing branch to Github and opening in browser."
 git push origin -u $branch_name
-open "https://github.com/SFDigitalServices/sf-dahlia-lap/compare/production...$branch_name?expand=1";
+open "https://github.com/SFDigitalServices/sf-dahlia-lap/tree/$branch_name";


### PR DESCRIPTION
## Description

Update our create_release_branch script to reflect our new release process after retiring `Production` branch. For now the script only creates a release branch and pushes it to Github. In the future it could automate tasks such as publishing the Jira and Github releases.

## Jira ticket

[DAH-2563](https://sfgovdt.jira.com/browse/DAH-2563)

## Checklist before requesting review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] [if the set of changes cannot be small, reviewers have been forewarned](https://google.github.io/eng-practices/review/developer/small-cls.html#cant)
- [x] code meets test coverage thresholds
- [x] code is properly formatted
- [x] code is linted
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] automated tests pass
- [x] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions have already been performed at least once
- [x] instructions can be followed by PA testers
- [x] instructions specify if it can only be followed by an engineer

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [x] If time sensitive, notify engineers in Slack

[DAH-2563]: https://sfgovdt.jira.com/browse/DAH-2563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ