### PR TITLE
fix: DAH-2790 fix checkmarks not showing up after perf improvements

### DIFF
--- a/app/javascript/components/lease_ups/LeaseUpApplicationsTableContainer.js
+++ b/app/javascript/components/lease_ups/LeaseUpApplicationsTableContainer.js
@@ -101,12 +101,15 @@ const LeaseUpTableContainer = ({
         (!hasFilters || (preferences && preferences.every((pref) => !pref.includes('Veteran'))))
       ) {
         const prefMap = {}
+        console.log('adding validations reload')
+        console.log(applications)
         addLayeredValidation(applications).forEach((preference) => {
           prefMap[`${preference.application_id}-${preference.preference_name}`] =
             preference.layered_validation
         })
         setPrefMap(prefMap)
       } else if (listingType !== LISTING_TYPE_FIRST_COME_FIRST_SERVED) {
+        console.log(applications)
         getApplications(listingId, 0, {}, true, false).then(({ records }) => {
           const prefMap = {}
           records.forEach((preference) => {
@@ -117,8 +120,43 @@ const LeaseUpTableContainer = ({
         })
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasFilters, listingId, listingType, preferences, usePerformanceUpdates])
+  }, [
+    flagsReady,
+    applications,
+    hasFilters,
+    listingId,
+    listingType,
+    preferences,
+    usePerformanceUpdates
+  ])
+
+  // useEffect(() => {
+  //   // don't need layered validation for fcfs
+  //   // don't need layered validation for non-veteran listings
+  //   // don't need layered validation for initial call
+  //   console.log(hasFilters)
+  //   if (!hasFilters && preferences && preferences.every((pref) => !pref.includes('Veteran'))) {
+  //     const prefMap = {}
+  //     console.log('in the if statement')
+  //     console.log(applications)
+  //     addLayeredValidation(applications).forEach((preference) => {
+  //       prefMap[`${preference.application_id}-${preference.preference_name}`] =
+  //         preference.layered_validation
+  //     })
+  //     setPrefMap(prefMap)
+  //   } else if (listingType !== LISTING_TYPE_FIRST_COME_FIRST_SERVED) {
+  //     console.log('in the else statement')
+  //     console.log(applications)
+  //     getApplications(listingId, 0, {}, true, false).then(({ records }) => {
+  //       const prefMap = {}
+  //       records.forEach((preference) => {
+  //         prefMap[`${preference.application_id}-${preference.preference_name}`] =
+  //           preference.layered_validation
+  //       })
+  //       setPrefMap(prefMap)
+  //     })
+  //   }
+  // }, [applications, hasFilters, listingId, listingType, preferences, usePerformanceUpdates])
 
   return (
     <>

--- a/app/javascript/components/lease_ups/LeaseUpApplicationsTableContainer.js
+++ b/app/javascript/components/lease_ups/LeaseUpApplicationsTableContainer.js
@@ -88,23 +88,17 @@ const LeaseUpTableContainer = ({
 
   useEffect(() => {
     if (!preferences) return
-    console.log('preferences:')
-    console.log(preferences)
     // don't need layered validation for fcfs
     // don't need layered validation for non-veteran listings
     // don't need layered validation for initial call
-    if (preferences && preferences.every((pref) => !pref.includes('Veteran'))) {
+    if (preferences.every((pref) => !pref.includes('Veteran'))) {
       const prefMap = {}
-      console.log('in if statement')
-      console.log(applications)
       addLayeredValidation(applications).forEach((preference) => {
         prefMap[`${preference.application_id}-${preference.preference_name}`] =
           preference.layered_validation
       })
       setPrefMap(prefMap)
     } else {
-      console.log('in else statement')
-      console.log(applications)
       getApplications(listingId, 0, {}, true, false).then(({ records }) => {
         const prefMap = {}
         records.forEach((preference) => {

--- a/app/javascript/components/lease_ups/LeaseUpApplicationsTableContainer.js
+++ b/app/javascript/components/lease_ups/LeaseUpApplicationsTableContainer.js
@@ -62,6 +62,35 @@ export const buildRowData = (application) => {
   return rowData
 }
 
+export const buildApplicationsWithLayeredValidations = (
+  listingId,
+  applications,
+  preferences,
+  setPrefMap
+) => {
+  if (!preferences) return
+  // don't need layered validation for fcfs
+  // don't need layered validation for non-veteran listings
+  // don't need layered validation for initial call
+  if (preferences.every((pref) => !pref.includes('Veteran'))) {
+    const prefMap = {}
+    addLayeredValidation(applications).forEach((preference) => {
+      prefMap[`${preference.application_id}-${preference.preference_name}`] =
+        preference.layered_validation
+    })
+    setPrefMap(prefMap)
+  } else {
+    getApplications(listingId, 0, {}, true, false).then(({ records }) => {
+      const prefMap = {}
+      records.forEach((preference) => {
+        prefMap[`${preference.application_id}-${preference.preference_name}`] =
+          preference.layered_validation
+      })
+      setPrefMap(prefMap)
+    })
+  }
+}
+
 const LeaseUpTableContainer = ({
   store: {
     applications,
@@ -87,27 +116,7 @@ const LeaseUpTableContainer = ({
   const [prefMap, setPrefMap] = useState(null)
 
   useEffect(() => {
-    if (!preferences) return
-    // don't need layered validation for fcfs
-    // don't need layered validation for non-veteran listings
-    // don't need layered validation for initial call
-    if (preferences.every((pref) => !pref.includes('Veteran'))) {
-      const prefMap = {}
-      addLayeredValidation(applications).forEach((preference) => {
-        prefMap[`${preference.application_id}-${preference.preference_name}`] =
-          preference.layered_validation
-      })
-      setPrefMap(prefMap)
-    } else {
-      getApplications(listingId, 0, {}, true, false).then(({ records }) => {
-        const prefMap = {}
-        records.forEach((preference) => {
-          prefMap[`${preference.application_id}-${preference.preference_name}`] =
-            preference.layered_validation
-        })
-        setPrefMap(prefMap)
-      })
-    }
+    buildApplicationsWithLayeredValidations(listingId, applications, preferences, setPrefMap)
   }, [applications, hasFilters, listingId, listingType, preferences])
 
   return (

--- a/app/javascript/components/lease_ups/LeaseUpApplicationsTableContainer.js
+++ b/app/javascript/components/lease_ups/LeaseUpApplicationsTableContainer.js
@@ -68,10 +68,10 @@ export const buildApplicationsWithLayeredValidations = (
   preferences,
   setPrefMap
 ) => {
+  // don't need layered validation for fcfs or listings that do not have preferences
   if (!preferences) return
-  // don't need layered validation for fcfs
-  // don't need layered validation for non-veteran listings
-  // don't need layered validation for initial call
+
+  // don't need to make additional calls to the backend for listings w/out veterans
   if (preferences.every((pref) => !pref.includes('Veteran'))) {
     const prefMap = {}
     addLayeredValidation(applications).forEach((preference) => {

--- a/app/javascript/components/lease_ups/LeaseUpApplicationsTableContainer.js
+++ b/app/javascript/components/lease_ups/LeaseUpApplicationsTableContainer.js
@@ -87,6 +87,7 @@ const LeaseUpTableContainer = ({
   const [prefMap, setPrefMap] = useState(null)
 
   useEffect(() => {
+    if (!preferences) return
     console.log('preferences:')
     console.log(preferences)
     // don't need layered validation for fcfs
@@ -101,7 +102,7 @@ const LeaseUpTableContainer = ({
           preference.layered_validation
       })
       setPrefMap(prefMap)
-    } else if (listingType !== LISTING_TYPE_FIRST_COME_FIRST_SERVED) {
+    } else {
       console.log('in else statement')
       console.log(applications)
       getApplications(listingId, 0, {}, true, false).then(({ records }) => {

--- a/spec/javascript/components/lease_ups/LeaseUpApplicationsTableContainer.test.js
+++ b/spec/javascript/components/lease_ups/LeaseUpApplicationsTableContainer.test.js
@@ -1,7 +1,13 @@
 import {
+  buildApplicationsWithLayeredValidations,
   buildRowData,
   getAccessibilityKeys
 } from 'components/lease_ups/LeaseUpApplicationsTableContainer'
+import { getApplications } from 'components/lease_ups/utils/leaseUpRequestUtils'
+
+jest.mock('components/lease_ups/utils/leaseUpRequestUtils.js', () => ({
+  getApplications: jest.fn()
+}))
 
 describe('LeaseUpApplicationsTableContainer', () => {
   describe('buildRowData', () => {
@@ -52,6 +58,52 @@ describe('LeaseUpApplicationsTableContainer', () => {
         }
       }
       expect(getAccessibilityKeys(application)).toBe('HCBS Units, Mobility')
+    })
+  })
+
+  describe('buildApplicationsWithLayeredValidations', () => {
+    test('should not call api when there are no preferences', async () => {
+      buildApplicationsWithLayeredValidations('listingId', [], [], () => {})
+      expect(getApplications).not.toHaveBeenCalled()
+    })
+
+    test('should not call api when there are no veteran preferences', async () => {
+      buildApplicationsWithLayeredValidations(
+        'listingId',
+        [],
+        [
+          'Live or Work in San Francisco Preference',
+          'Neighborhood Resident Housing Preference (NRHP)'
+        ],
+        () => {}
+      )
+      expect(getApplications).not.toHaveBeenCalled()
+    })
+
+    test('should call api when there are veteran preferences', async () => {
+      getApplications.mockImplementation(() =>
+        Promise.resolve({
+          records: [
+            {
+              application_id: 'application_id',
+              preference_name: 'preference_name',
+              layered_validation: 'Confirmed'
+            }
+          ]
+        })
+      )
+
+      buildApplicationsWithLayeredValidations(
+        'listingId',
+        [],
+        [
+          'Tier 1 Veteran with Certificate of Preference',
+          'Live or Work in San Francisco Preference',
+          'Neighborhood Resident Housing Preference (NRHP)'
+        ],
+        () => {}
+      )
+      expect(getApplications).toHaveBeenCalledTimes(1)
     })
   })
 })


### PR DESCRIPTION
## Description

This fixes an issue where confirmation checkmarks where not showing up on the lease up listing page after [these](https://sfgovdt.jira.com/browse/DAH-2698) performance improvements

## Jira ticket

[DAH-2790](https://sfgovdt.jira.com/browse/DAH-2790)

## Checklist before requesting review

### Version Control

- [x] branch name begins with `angular` if it contains updates to Angular code
- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, e.g. `feat: DAH-123 New Feature`

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] code irrelevant to the ticket is not modified e.g. changing indentation due to automated formatting
- [x] if the code changes the UI, it matches the UI design exactly

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [x] If time sensitive, notify engineers in Slack

[DAH-2764]: https://sfgovdt.jira.com/browse/DAH-2764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DAH-2790]: https://sfgovdt.jira.com/browse/DAH-2790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ