### PR TITLE
fix: DAH-2889 regex for checking preferences

### DIFF
--- a/app/javascript/components/supplemental_application/sections/preferences/utils.js
+++ b/app/javascript/components/supplemental_application/sections/preferences/utils.js
@@ -13,9 +13,9 @@ export const isCOP = testRegex(/COP/)
 
 export const isDTHP = testRegex(/DTHP/)
 
-export const isAliceGriffith = testRegex(/Griffith/)
+export const isAliceGriffith = testRegex(/AG/)
 
-export const isRightToReturn = testRegex(/Right to Return/)
+export const isRightToReturn = testRegex(/RTR/)
 
 export const isLWinSF = (value) => value === 'Live or Work in San Francisco Preference'
 


### PR DESCRIPTION
DAH-2889

The regex needed to be updated to check preferences because it is checking against short code, not preference name.