### PR TITLE
fix: hardcoding year to prevent updating the test every year

### DIFF
--- a/spec/javascript/components/supplemental_application/SupplementalApplicationPage.test.js
+++ b/spec/javascript/components/supplemental_application/SupplementalApplicationPage.test.js
@@ -187,11 +187,17 @@ describe('SupplementalApplicationPage', () => {
   })
 
   test('it should render as expected', async () => {
+    jest.useFakeTimers()
+    const mockDate = new Date('2024-06-01T00:00:00Z')
+    jest.setSystemTime(mockDate)
+
     const { asFragment } = await act(() =>
       render(leaseUpAppWithUrl(getWindowUrl(getMockApplication().id)))
     )
 
     expect(asFragment()).toMatchSnapshot()
+
+    jest.useRealTimers()
   })
 
   test('it only performs initial load request if nothing is changed', async () => {


### PR DESCRIPTION
## Description

Hardcode the year for supplemental application test to avoid having to change the test every year

## Jira ticket

n/a

## Review instructions

`frontend` tests that are failing on the [main](https://github.com/SFDigitalServices/sf-dahlia-lap/commits/main/) branch should pass on this PR
