### PR TITLE
fix: DAH-3505 checking if occupied unit lease is for current applicant

### DIFF
--- a/app/javascript/components/supplemental_application/sections/Lease.js
+++ b/app/javascript/components/supplemental_application/sections/Lease.js
@@ -169,7 +169,11 @@ const Lease = ({ form, values }) => {
    */
   const unavailableStatuses = ['Draft', 'Signed']
   const availableUnits = state.units.filter((unit) => {
-    if (unitStatusFlagEnabled) return unit.status && unit.status === UNIT_STATUS_AVAILABLE
+    if (unitStatusFlagEnabled)
+      return (
+        (unit.status && unit.status === UNIT_STATUS_AVAILABLE) ||
+        (unit.leases && unit.leases.some((lease) => lease.application_id === state.application.id))
+      )
 
     return (
       !Array.isArray(unit.leases) ||

--- a/app/javascript/components/supplemental_application/sections/Lease.js
+++ b/app/javascript/components/supplemental_application/sections/Lease.js
@@ -159,7 +159,7 @@ const Lease = ({ form, values }) => {
 
   /**
    * available units fit the following criteria
-   *  - if unitStatusFlagEnabled, check unit status is not occupied
+   *  - if unitStatusFlagEnabled, check unit status is available or lease is for current application
    *  - else
    *    - if it doesn't have any leases
    *    - if there are leases, they cannot be in draft or signed status

--- a/spec/javascript/components/supplemental_application/SupplementalApplicationPage.test.js
+++ b/spec/javascript/components/supplemental_application/SupplementalApplicationPage.test.js
@@ -52,6 +52,12 @@ jest.mock('apiService', () => {
         appWithPrefs.listing.id = _ID_NO_AVAILABLE_UNITS
       }
 
+      if (applicationId === 'testId') {
+        // let the listing know that it should have no available units.
+        appWithPrefs.id = 'testId'
+        appWithPrefs.listing.id = 'testId'
+      }
+
       _merge(appWithPrefs.preferences[0], {
         preference_name: 'Rent Burdened Assisted Housing',
         individual_preference: 'Rent Burdened',
@@ -670,14 +676,14 @@ describe('SupplementalApplicationPage', () => {
     describe('partners.unitStatus feature toggle', () => {
       test('shows available units based on leases when toggle is off', async () => {
         useFlagUnleash.mockImplementation(() => false)
-        await getWrapper()
-        expect(screen.getByTestId('total-available-count').textContent).toBe('2')
+        await getWrapper('testId')
+        expect(screen.getByTestId('total-available-count').textContent).toBe('3')
       })
 
       test('shows available units based on unit status when toggle is on', async () => {
         useFlagUnleash.mockImplementation(() => true)
-        await getWrapper()
-        expect(screen.getByTestId('total-available-count').textContent).toBe('1')
+        await getWrapper('testId')
+        expect(screen.getByTestId('total-available-count').textContent).toBe('2')
       })
     })
   })

--- a/spec/javascript/components/supplemental_application/SupplementalApplicationPage.test.js
+++ b/spec/javascript/components/supplemental_application/SupplementalApplicationPage.test.js
@@ -22,6 +22,9 @@ const getWindowUrl = (id) => `/lease-ups/applications/${id}`
 const ID_NO_AVAILABLE_UNITS = 'idwithnoavailableunits'
 const ID_WITH_TOTAL_MONTHLY_RENT = 'idwithtotalmonthlyrent'
 
+const LISTING_ID_WITH_LEASE_MATCHING_APPLICANT = 'listingidwithleasematchingapplicant'
+const APPLICATION_ID_WITH_LEASE_MATCHING_APPLICANT = 'applicationidwithleasematchingapplicant'
+
 jest.mock('@unleash/proxy-client-react')
 
 /**
@@ -52,10 +55,9 @@ jest.mock('apiService', () => {
         appWithPrefs.listing.id = _ID_NO_AVAILABLE_UNITS
       }
 
-      if (applicationId === 'testId') {
-        // let the listing know that it should have no available units.
-        appWithPrefs.id = 'testId'
-        appWithPrefs.listing.id = 'testId'
+      if (applicationId === APPLICATION_ID_WITH_LEASE_MATCHING_APPLICANT) {
+        appWithPrefs.id = APPLICATION_ID_WITH_LEASE_MATCHING_APPLICANT
+        appWithPrefs.listing.id = LISTING_ID_WITH_LEASE_MATCHING_APPLICANT
       }
 
       _merge(appWithPrefs.preferences[0], {
@@ -102,7 +104,7 @@ jest.mock('apiService', () => {
         status: 'Occupied',
         leases: [
           {
-            application_id: 'testId',
+            application_id: APPLICATION_ID_WITH_LEASE_MATCHING_APPLICANT,
             preference_used_name: '',
             lease_status: 'Signed'
           }
@@ -676,13 +678,13 @@ describe('SupplementalApplicationPage', () => {
     describe('partners.unitStatus feature toggle', () => {
       test('shows available units based on leases when toggle is off', async () => {
         useFlagUnleash.mockImplementation(() => false)
-        await getWrapper('testId')
+        await getWrapper(APPLICATION_ID_WITH_LEASE_MATCHING_APPLICANT)
         expect(screen.getByTestId('total-available-count').textContent).toBe('3')
       })
 
       test('shows available units based on unit status when toggle is on', async () => {
         useFlagUnleash.mockImplementation(() => true)
-        await getWrapper('testId')
+        await getWrapper(APPLICATION_ID_WITH_LEASE_MATCHING_APPLICANT)
         expect(screen.getByTestId('total-available-count').textContent).toBe('2')
       })
     })


### PR DESCRIPTION
## Description

Addresses a bug where leasing agents were not able to see signed leases for an applicant

## Jira ticket

[DAH-3505](https://sfgovdt.jira.com/browse/DAH-3505)

## Before requesting eng review

### Version Control

- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] if the PR is a bugfix, there are tests and logs around the bug

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag


[DAH-3505]: https://sfgovdt.jira.com/browse/DAH-3505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ