### PR TITLE
feat: DAH-3338 remove deprecated ssl options

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ defaults: &defaults
         RAILS_ENV: development
         PGHOST: 127.0.0.1
         PGUSER: root
-        NODE_OPTIONS: --openssl-legacy-provider --max_old_space_size=4096
+        NODE_OPTIONS: --max_old_space_size=4096
     - image: 'cypress/base:14.15.0'
   executor: ruby/default
 non_production_jobs: &non_production_jobs

--- a/app.json
+++ b/app.json
@@ -37,10 +37,6 @@
     },
     "SECRET_KEY_BASE": {
       "required": true
-    },
-    "NODE_OPTIONS": {
-      "required": false,
-      "value": "--openssl-legacy-provider"
     }
   },
   "formation": {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "lint:fix": "eslint --fix --ext .js,.jsx app/ spec/",
     "rails-server": "rails s",
     "webpack-hot": "bin/shakapacker-dev-server --hot",
-    "start": "NODE_OPTIONS=\"--openssl-legacy-provider\" npm-run-all -p -l webpack-hot rails-server",
+    "start": "npm-run-all -p -l webpack-hot rails-server",
     "print_release_info": "bash $PWD/print_release_info.sh",
     "create_release_branch": "bash $PWD/create_release_branch.sh",
     "deduplicate": "yarn yarn-deduplicate -s fewer yarn.lock && yarn install"


### PR DESCRIPTION
## Description

Locally and in Heroku we are already using openssl 3, this PR removes the unnecessary legacy ssl options during app startup.

## Jira ticket

[DAH-3338](https://sfgovdt.jira.com/browse/DAH-3338)

## Before requesting eng review

### Version Control

- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag


[DAH-3337]: https://sfgovdt.jira.com/browse/DAH-3337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DAH-3338]: https://sfgovdt.jira.com/browse/DAH-3338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ