### PR TITLE
urgent: remove restforce debugging logs

### DIFF
--- a/app/services/force/client_factory.rb
+++ b/app/services/force/client_factory.rb
@@ -16,7 +16,6 @@ module Force
     end
 
     def new_with_oauth_token(oauth_token)
-      Restforce.log = true
       Restforce.new(
         authentication_retries: 1,
         oauth_token: oauth_token,

--- a/app/services/force/client_factory.rb
+++ b/app/services/force/client_factory.rb
@@ -20,7 +20,6 @@ module Force
         authentication_retries: 1,
         oauth_token: oauth_token,
         instance_url: ENV['SALESFORCE_INSTANCE_URL'],
-        log_level: :debug,
       )
     end
   end


### PR DESCRIPTION
## Description

Disable restforce, which are adding too data to our logging service. They were enabled for debugging and were not meant to be deployed.

## Jira ticket

https://sfgovdt.jira.com/browse/<JIRA TICKET NUMBER>

## Before requesting eng review

### Version Control

- [ ] branch name contains the Jira ticket number
- [ ] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [x] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Review instructions

- [ ] instructions specify which environment(s) it applies to
- [ ] instructions work for PA testers
- [ ] instructions have already been performed at least once

### Request eng review

- [ ] PR has `needs review` label
- [ ] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag
