### PR TITLE
fix: DAH-3809 Format datestrings to have double digits

### DIFF
--- a/app/services/dahlia_backend/message_service.rb
+++ b/app/services/dahlia_backend/message_service.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'date'
+
 module DahliaBackend
   # Service for sending messages through the DAHLIA API
   class MessageService
@@ -35,6 +37,8 @@ module DahliaBackend
       raise 'No contacts found' if contacts.empty?
 
       listing = params[:listing]
+      lottery_date = DateTime.parse(listing[:lottery_date])
+      deadline_date = DateTime.parse(params[:invite_to_apply_deadline])
       {
         "isTestEmail": params[:isTest] ? true : false,
         "listingId": listing[:id],
@@ -47,8 +51,8 @@ module DahliaBackend
         "listingNeighborhood": listing[:neighborhood],
         "units": prepare_units(listing[:id]),
         "applicants": contacts,
-        "deadlineDate": params[:invite_to_apply_deadline],
-        "lotteryDate": listing[:lottery_date],
+        "deadlineDate": deadline_date.strftime('%Y-%m-%d'),
+        "lotteryDate": lottery_date.strftime('%Y-%m-%d'),
         "leasingAgent": {
           "name": listing[:leasing_agent_name],
           "email": determine_email(listing[:leasing_agent_email]),


### PR DESCRIPTION
## Description

Formats the day and month portions of date strings look like "01" instead of "1"

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3809

## Before requesting eng review

### Version Control

- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [ ] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag
