### PR TITLE
fix: DAH-3800 Add comment does not inherit substatus

### DIFF
--- a/app/javascript/components/lease_ups/LeaseUpApplicationsPage.js
+++ b/app/javascript/components/lease_ups/LeaseUpApplicationsPage.js
@@ -213,18 +213,19 @@ const LeaseUpApplicationsPage = () => {
   const handleStatusModalSubmit = async (submittedValues) => {
     setStatusModalState({ loading: true })
     const { applicationsData } = statusModalState
-    let { status, subStatus } = submittedValues
+    const { status, subStatus } = submittedValues
 
     Object.keys(applicationsData).forEach((appId) => {
       applicationsData[appId].comment = submittedValues.comment?.trim()
 
-      // substatus might be a comment
-      // make sure it's valid or an empty string
-      if (!find(LEASE_UP_SUBSTATUS_OPTIONS[status] || [], { value: subStatus })) {
-        subStatus = ''
-        // status might not be set. agent just wants to add a comment.
-        // so make sure invalid substatus is cleared out.
-        applicationsData[appId].subStatus = subStatus
+      // previous substatus might be a comment
+      // clear it out if so
+      if (
+        !find(LEASE_UP_SUBSTATUS_OPTIONS[applicationsData[appId].status] || [], {
+          value: applicationsData[appId].subStatus
+        })
+      ) {
+        applicationsData[appId].subStatus = ''
       }
 
       if (status) {


### PR DESCRIPTION
## Description

Fixes a bug where the substatus does not get inherited when using the Add comment button.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3800

## Before requesting eng review

### Version Control

- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag
