### PR TITLE
fix: DAH-3829 MALFORMED_QUERY error when a listing has no applications

### DIFF
--- a/app/services/force/field_update_comment_service.rb
+++ b/app/services/force/field_update_comment_service.rb
@@ -33,6 +33,8 @@ module Force
     end
 
     def bulk_status_history_by_applications(application_ids)
+      return [] if application_ids.empty?
+
       quoted_ids = application_ids.map { |item| "'#{item}'" }
       result = parsed_index_query(
         %(


### PR DESCRIPTION
## Description

Fix an error when a listing has no applications

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3829

## Before requesting eng review

### Version Control

- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [ ] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [x] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag
