### PR TITLE
feat: DAH-3756 display applicants without email

### DIFF
--- a/app/assets/stylesheets/lap.scss
+++ b/app/assets/stylesheets/lap.scss
@@ -158,3 +158,12 @@ ul.bullet-list {
 .success-alert .info-alert-inner .info-alert-body {
   width: 90%;
 }
+
+.primary-alert .info-alert-inner {
+  border: 2px solid #DAEEFF;
+  background-color: #F5F8F9;  
+  border-radius: 4px;
+  .info-alert-body {
+    width: 90%;
+  }
+}

--- a/app/javascript/components/lease_ups/InviteToApplyModals.js
+++ b/app/javascript/components/lease_ups/InviteToApplyModals.js
@@ -317,19 +317,21 @@ export const InviteToApplyModals = forwardRef((props, ref) => {
               <label className='form-label'>Send to</label>
               {getSelectedApplicationIds().length} applicants and alternate contacts, if provided
             </p>
-            <InfoAlert
-              message={
-                <span>
-                  <strong>
-                    {`${checkedAppsWithoutEmail()} applicants you selected do not have an email address. `}
-                  </strong>
-                  After sending, we will show who you still need to contact on the applicant list.
-                </span>
-              }
-              icon='i-info'
-              closeType='none'
-              classes={['primary-alert']}
-            />
+            {checkedAppsWithoutEmail() > 0 && (
+              <InfoAlert
+                message={
+                  <span>
+                    <strong>
+                      {`${checkedAppsWithoutEmail()} applicants you selected do not have an email address. `}
+                    </strong>
+                    After sending, we will show who you still need to contact on the applicant list.
+                  </span>
+                }
+                icon='i-info'
+                closeType='none'
+                classes={['primary-alert']}
+              />
+            )}
           </div>
         )}
       </FormModal>

--- a/app/javascript/components/lease_ups/InviteToApplyModals.js
+++ b/app/javascript/components/lease_ups/InviteToApplyModals.js
@@ -312,11 +312,19 @@ export const InviteToApplyModals = forwardRef((props, ref) => {
               <label className='form-label'>Send to</label>
               {getSelectedApplicationIds().length} applicants and alternate contacts, if provided
             </p>
-            <p>
-              {checkedAppsWithoutEmail()} applicant{checkedAppsWithoutEmail() !== 1 && 's'} you
-              selected do not have an email address. After sending, we will show who you still need
-              to contact on the applicant list.
-            </p>
+            <InfoAlert
+              message={
+                <span>
+                  <strong>
+                    {`${checkedAppsWithoutEmail()} applicants you selected do not have an email address. `}
+                  </strong>
+                  After sending, we will show who you still need to contact on the applicant list.
+                </span>
+              }
+              icon='i-info'
+              closeType='none'
+              classes={['success-alert']}
+            />
           </div>
         )}
       </FormModal>

--- a/app/javascript/components/lease_ups/InviteToApplyModals.js
+++ b/app/javascript/components/lease_ups/InviteToApplyModals.js
@@ -323,7 +323,7 @@ export const InviteToApplyModals = forwardRef((props, ref) => {
               }
               icon='i-info'
               closeType='none'
-              classes={['success-alert']}
+              classes={['primary-alert']}
             />
           </div>
         )}

--- a/app/javascript/components/lease_ups/InviteToApplyModals.js
+++ b/app/javascript/components/lease_ups/InviteToApplyModals.js
@@ -132,6 +132,13 @@ export const InviteToApplyModals = forwardRef((props, ref) => {
     return errs
   }
 
+  const checkedAppsWithoutEmail = () => {
+    const selectedIds = getSelectedApplicationIds()
+    return props.applications.filter(
+      (app) => !app.email && selectedIds.includes(app.application_id)
+    ).length
+  }
+
   const sendInviteToApply = (values) => {
     const appIds = getSelectedApplicationIds()
     const deadline = rsvpModalValues[INVITE_APPLY_DEADLINE_KEY]
@@ -304,6 +311,11 @@ export const InviteToApplyModals = forwardRef((props, ref) => {
             <p>
               <label className='form-label'>Send to</label>
               {getSelectedApplicationIds().length} applicants and alternate contacts, if provided
+            </p>
+            <p>
+              {checkedAppsWithoutEmail()} applicant{checkedAppsWithoutEmail() !== 1 && 's'} you
+              selected do not have an email address. After sending, we will show who you still need
+              to contact on the applicant list.
             </p>
           </div>
         )}

--- a/app/javascript/components/lease_ups/LeaseUpApplicationsTableContainer.js
+++ b/app/javascript/components/lease_ups/LeaseUpApplicationsTableContainer.js
@@ -161,6 +161,7 @@ const LeaseUpTableContainer = ({
         listingId={listingId}
         listing={listing}
         setPageState={setPageState}
+        applications={applications}
       />
     </>
   )

--- a/app/javascript/components/molecules/InfoAlert.js
+++ b/app/javascript/components/molecules/InfoAlert.js
@@ -29,12 +29,10 @@ const InfoAlert = ({ icon, message, onCloseClick, closeType, classes = [] }) => 
   })
   const combinedClasses = classNames(defaultClasses)
 
-  const closeLink = getCloseLink(closeType, onCloseClick)
-
   return (
     <div className={combinedClasses}>
       <div data-info className='info-alert-inner'>
-        {closeLink}
+        {closeType !== 'none' && getCloseLink(closeType, onCloseClick)}
         <span className='info-alert-icon ui-icon ui-medium'>
           <svg>
             <use xlinkHref={`#${icon}`} />

--- a/app/services/force/graphql/lease_up_application_preferences.rb
+++ b/app/services/force/graphql/lease_up_application_preferences.rb
@@ -64,6 +64,7 @@ module Force
                           Last_Name__c {value}
                           Residence_Address__c {value}
                           Mailing_Address__c {value}
+                          Email__c {value}
                         }
                       }
                     }


### PR DESCRIPTION
## Description

Displays the number of applicants without an email address on the Partners review and send modal. 

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3756

## Before requesting eng review

### Version Control

- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag
