### PR TITLE
chore: DAH-0000 resolve flaky SupplementalApplicationPage tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jest": "^27.6.2",
     "eslint-plugin-jsx-a11y": "^6.8.0",
+    "eslint-plugin-n": "^17.23.2",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-promise": "^6.1.1",

--- a/spec/javascript/components/supplemental_application/SupplementalApplicationPage.test.js
+++ b/spec/javascript/components/supplemental_application/SupplementalApplicationPage.test.js
@@ -1,9 +1,13 @@
-import { render, screen, fireEvent, within, act } from '@testing-library/react'
+import { render, screen, fireEvent, within, act, waitFor } from '@testing-library/react'
 import { useFlag as useFlagUnleash, useFlagsStatus, useVariant } from '@unleash/proxy-client-react'
 import { cloneDeep } from 'lodash'
 import selectEvent from 'react-select-event'
 
 import supplementalApplication from '../../fixtures/supplemental_application'
+
+// Increase default test timeout for this file - tests involve multiple async operations
+// and can be slow in resource-constrained environments (e.g., VS Code terminal)
+jest.setTimeout(15000)
 import { leaseUpAppWithUrl, renderAppWithUrl } from '../../testUtils/wrapperUtil'
 
 const mockInitialLoad = jest.fn()
@@ -191,7 +195,16 @@ jest.mock('apiService', () => {
   }
 })
 const getWrapper = async (id = getMockApplication().id) => {
-  return await act(async () => renderAppWithUrl(getWindowUrl(id)))
+  const result = await act(async () => renderAppWithUrl(getWindowUrl(id)))
+  // Wait for the page to finish loading by waiting for the form to appear
+  // Increase timeout to 5s since async data loading can take time under load
+  await waitFor(
+    () => {
+      expect(screen.getByRole('form')).toBeInTheDocument()
+    },
+    { timeout: 5000 }
+  )
+  return result
 }
 
 describe('SupplementalApplicationPage', () => {
@@ -298,11 +311,13 @@ describe('SupplementalApplicationPage', () => {
         { target: { value: '0' } }
       )
     )
-    fireEvent.change(
-      screen.getByRole('combobox', {
-        name: /primary applicant marital status/i
-      }),
-      { target: { value: 'Domestic Partner' } }
+    await act(() =>
+      fireEvent.change(
+        screen.getByRole('combobox', {
+          name: /primary applicant marital status/i
+        }),
+        { target: { value: 'Domestic Partner' } }
+      )
     )
 
     await act(() => {
@@ -316,6 +331,14 @@ describe('SupplementalApplicationPage', () => {
   describe('preference panel', () => {
     test('it saves a live/work application preference panel', async () => {
       await getWrapper()
+
+      // Wait for the expandable table rows to be rendered after async data loads
+      await waitFor(
+        () => {
+          expect(screen.getAllByTestId('expandable-table-row').length).toBeGreaterThan(3)
+        },
+        { timeout: 5000 }
+      )
 
       expect(screen.getAllByTestId('expandable-table-row')[3]).toHaveAttribute(
         'aria-expanded',
@@ -470,7 +493,9 @@ describe('SupplementalApplicationPage', () => {
     test('should save a lease object', async () => {
       await getWrapper()
 
-      fireEvent.click(screen.getByRole('button', { name: /edit lease/i }))
+      // Wait for the edit lease button to be available after async data loads
+      const editLeaseButton = await screen.findByRole('button', { name: /edit lease/i }, { timeout: 5000 })
+      fireEvent.click(editLeaseButton)
 
       const leaseStartDate = screen.getAllByTestId('multi-date-field')[1]
       const monthInput = within(leaseStartDate).getAllByRole('textbox')[0]
@@ -482,7 +507,7 @@ describe('SupplementalApplicationPage', () => {
       // Fill out lease fields
       // Assigned Unit number
 
-      selectEvent.openMenu(
+      await selectEvent.openMenu(
         within(
           screen.getByRole('button', {
             name: /assigned unit number/i
@@ -571,13 +596,16 @@ describe('SupplementalApplicationPage', () => {
       expect(mockCreateLease.mock.calls).toHaveLength(0)
       expect(mockUpdateLease.mock.calls).toHaveLength(1)
       expect(mockUpdateLease).toHaveBeenCalledWith(expectedLease)
-    }, 10000)
+    }, 20000)
 
     test('it displays "No Units Available" and 0 units count when no units available', async () => {
       await getWrapper(ID_NO_AVAILABLE_UNITS)
-      const unitSelect = screen.getByRole('button', {
-        name: /assigned unit number/i
-      })
+      // Wait for the unit select to be available after async units data loads
+      const unitSelect = await screen.findByRole(
+        'button',
+        { name: /assigned unit number/i },
+        { timeout: 5000 }
+      )
 
       expect(within(unitSelect).getByText('No Units Available')).toBeInTheDocument()
       expect(screen.getByTestId('total-available-count').textContent).toBe('0')
@@ -614,7 +642,7 @@ describe('SupplementalApplicationPage', () => {
 
         fireEvent.click(screen.getByRole('button', { name: /edit lease/i }))
 
-        selectEvent.openMenu(
+        await selectEvent.openMenu(
           within(
             screen.getByRole('button', {
               name: /assigned unit number/i
@@ -622,7 +650,7 @@ describe('SupplementalApplicationPage', () => {
           ).getByRole('combobox')
         )
 
-        act(() => {
+        await act(() => {
           fireEvent.click(screen.getByText(/unit without priority/i))
         })
       })
@@ -659,7 +687,7 @@ describe('SupplementalApplicationPage', () => {
 
         fireEvent.click(screen.getByRole('button', { name: /edit lease/i }))
 
-        selectEvent.openMenu(
+        await selectEvent.openMenu(
           within(
             screen.getByRole('button', {
               name: /assigned unit number/i
@@ -668,7 +696,7 @@ describe('SupplementalApplicationPage', () => {
         )
 
         await act(async () => {
-          await fireEvent.click(screen.getByText(/unit with priority/i))
+          fireEvent.click(screen.getByText(/unit with priority/i))
         })
       })
 

--- a/spec/javascript/components/supplemental_application/SupplementalApplicationPage.test.js
+++ b/spec/javascript/components/supplemental_application/SupplementalApplicationPage.test.js
@@ -4,11 +4,11 @@ import { cloneDeep } from 'lodash'
 import selectEvent from 'react-select-event'
 
 import supplementalApplication from '../../fixtures/supplemental_application'
+import { leaseUpAppWithUrl, renderAppWithUrl } from '../../testUtils/wrapperUtil'
 
 // Increase default test timeout for this file - tests involve multiple async operations
 // and can be slow in resource-constrained environments (e.g., VS Code terminal)
 jest.setTimeout(15000)
-import { leaseUpAppWithUrl, renderAppWithUrl } from '../../testUtils/wrapperUtil'
 
 const mockInitialLoad = jest.fn()
 const mockSubmitApplication = jest.fn()
@@ -494,7 +494,11 @@ describe('SupplementalApplicationPage', () => {
       await getWrapper()
 
       // Wait for the edit lease button to be available after async data loads
-      const editLeaseButton = await screen.findByRole('button', { name: /edit lease/i }, { timeout: 5000 })
+      const editLeaseButton = await screen.findByRole(
+        'button',
+        { name: /edit lease/i },
+        { timeout: 5000 }
+      )
       fireEvent.click(editLeaseButton)
 
       const leaseStartDate = screen.getAllByTestId('multi-date-field')[1]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1513,12 +1513,24 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz#d0fce5d07b0620caa282b5131c297bb60f9d87e6"
   integrity sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==
 
+"@eslint-community/eslint-utils@^4.1.2", "@eslint-community/eslint-utils@^4.5.0":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz#4e90af67bc51ddee6cdef5284edf572ec376b595"
+  integrity sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==
+  dependencies:
+    eslint-visitor-keys "^3.4.3"
+
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
   integrity sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==
   dependencies:
     eslint-visitor-keys "^3.3.0"
+
+"@eslint-community/regexpp@^4.11.0":
+  version "4.12.2"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.12.2.tgz#bccdf615bcf7b6e8db830ec0b8d21c9a25de597b"
+  integrity sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==
 
 "@eslint-community/regexpp@^4.6.1":
   version "4.10.0"
@@ -4857,6 +4869,13 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-compat-utils@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz#7fc92b776d185a70c4070d03fd26fde3d59652e4"
+  integrity sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==
+  dependencies:
+    semver "^7.5.4"
+
 eslint-config-prettier@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz#31af3d94578645966c082fcb71a5846d3c94867f"
@@ -4906,6 +4925,15 @@ eslint-plugin-cypress@^2.15.1:
   integrity sha512-eLHLWP5Q+I4j2AWepYq0PgFEei9/s5LvjuSqWrxurkg1YZ8ltxdvMNmdSf0drnsNo57CTgYY/NIHHLRSWejR7w==
   dependencies:
     globals "^13.20.0"
+
+eslint-plugin-es-x@^7.8.0:
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz#a207aa08da37a7923f2a9599e6d3eb73f3f92b74"
+  integrity sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.1.2"
+    "@eslint-community/regexpp" "^4.11.0"
+    eslint-compat-utils "^0.5.1"
 
 eslint-plugin-es@^3.0.0:
   version "3.0.1"
@@ -5003,6 +5031,21 @@ eslint-plugin-n@^15.7.0:
     minimatch "^3.1.2"
     resolve "^1.22.1"
     semver "^7.3.8"
+
+eslint-plugin-n@^17.23.2:
+  version "17.23.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-n/-/eslint-plugin-n-17.23.2.tgz#cd1be342b56771385028d8039d67f11fb9cca5f3"
+  integrity sha512-RhWBeb7YVPmNa2eggvJooiuehdL76/bbfj/OJewyoGT80qn5PXdz8zMOTO6YHOsI7byPt7+Ighh/i/4a5/v7hw==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.5.0"
+    enhanced-resolve "^5.17.1"
+    eslint-plugin-es-x "^7.8.0"
+    get-tsconfig "^4.8.1"
+    globals "^15.11.0"
+    globrex "^0.1.2"
+    ignore "^5.3.2"
+    semver "^7.6.3"
+    ts-declaration-location "^1.0.6"
 
 eslint-plugin-node@^11.1.0:
   version "11.1.0"
@@ -5873,6 +5916,13 @@ get-symbol-description@^1.0.0:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
 
+get-tsconfig@^4.8.1:
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.13.0.tgz#fcdd991e6d22ab9a600f00e91c318707a5d9a0d7"
+  integrity sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==
+  dependencies:
+    resolve-pkg-maps "^1.0.0"
+
 getobject@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/getobject/-/getobject-1.0.2.tgz#25ec87a50370f6dcc3c6ba7ef43c4c16215c4c89"
@@ -5987,6 +6037,11 @@ globals@^13.19.0, globals@^13.20.0:
   dependencies:
     type-fest "^0.20.2"
 
+globals@^15.11.0:
+  version "15.15.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-15.15.0.tgz#7c4761299d41c32b075715a4ce1ede7897ff72a8"
+  integrity sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==
+
 globals@^9.14.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
@@ -6010,6 +6065,11 @@ globby@^11.1.0:
     ignore "^5.2.0"
     merge2 "^1.4.1"
     slash "^3.0.0"
+
+globrex@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
+  integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
 
 gopd@^1.0.1:
   version "1.0.1"
@@ -6405,6 +6465,11 @@ ignore@^5.1.1, ignore@^5.2.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.0.tgz#67418ae40d34d6999c95ff56016759c718c82f78"
   integrity sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==
+
+ignore@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
+  integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
 immediate@~3.0.5:
   version "3.0.6"
@@ -8588,6 +8653,11 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+picomatch@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
+  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
+
 pidtree@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.3.1.tgz#ef09ac2cc0533df1f3250ccf2c4d366b0d12114a"
@@ -9758,6 +9828,11 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
+resolve-pkg-maps@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz#616b3dc2c57056b5588c31cdf4b3d64db133720f"
+  integrity sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==
+
 resolve.exports@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-2.0.2.tgz#f8c934b8e6a13f539e38b7098e2e36134f01e800"
@@ -9977,6 +10052,11 @@ semver@^7.0.0, semver@^7.3.7, semver@^7.3.8, semver@^7.5.0, semver@^7.5.3, semve
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^7.6.3:
+  version "7.7.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.3.tgz#4b5f4143d007633a8dc671cd0a6ef9147b8bb946"
+  integrity sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==
 
 send@0.19.0:
   version "0.19.0"
@@ -10768,6 +10848,13 @@ tree-kill@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
+
+ts-declaration-location@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/ts-declaration-location/-/ts-declaration-location-1.0.7.tgz#d4068fe9975828b3b453b3ab112b4711d8267688"
+  integrity sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==
+  dependencies:
+    picomatch "^4.0.2"
 
 tsconfig-paths@^3.15.0:
   version "3.15.0"


### PR DESCRIPTION
## Description

Add proper async handling to tests that were failing intermittently due to race conditions. Tests were querying for DOM elements before async data loading completed. This was causing `SupplementalApplicationPage.test.js` to sometimes fail in slower environments on Windows, like the VS Code terminal, but then it would work in the Windows terminal. Ensuring that async calls are always awaited and bumping the timeouts seems to have fixed it.

Changes:
- Add waitFor to getWrapper() to ensure form is loaded before tests run
- Use findByRole instead of getByRole for elements that appear after async ops
- Add await to selectEvent.openMenu() calls which are async
- Wrap remaining state-changing interactions in await act()

## Before requesting eng review

### Version Control

- [ ] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Review instructions

- [ ] instructions specify which environment(s) it applies to
- [ ] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [ ] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag
