### PR TITLE
urgent: fix: DAH-3943 Fix applications preferences table not stretching width of the header on application details page

### DIFF
--- a/app/assets/stylesheets/lap.scss
+++ b/app/assets/stylesheets/lap.scss
@@ -169,7 +169,7 @@ ul.bullet-list {
   }
 }
 
-.i2a-selected-apps-table thead, tbody {
+.i2a-selected-apps-table thead, .i2a-selected-apps-table tbody {
   display: block
 }
 


### PR DESCRIPTION
## Description

Update css rule so that it only applies to the i2a one url per app table.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3943

## Before requesting eng review

### Version Control

- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [ ] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [x] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag
