### PR TITLE
fix: DAH-3956 display substatus in lease up application table

### DIFF
--- a/app/javascript/components/lease_ups/leaseUpAppFirstComeFirstServedModel.js
+++ b/app/javascript/components/lease_ups/leaseUpAppFirstComeFirstServedModel.js
@@ -1,3 +1,5 @@
+import { getSubStatusLabel } from '../../utils/statusUtils'
+
 export const buildLeaseUpAppFirstComeFirstServedModel = (application) => {
   const applicant = application.applicant
 
@@ -15,6 +17,7 @@ export const buildLeaseUpAppFirstComeFirstServedModel = (application) => {
     has_ada_priorities_selected: application.has_ada_priorities_selected,
     total_household_size: application.total_household_size,
     sub_status: application.sub_status,
+    sub_status_label: getSubStatusLabel(application.processing_status, application.sub_status),
     // preference order doesn't matter for fcfs listings and all applications are 'General'
     preference_lottery_rank: application.general_lottery_rank,
     preference_order: 1,

--- a/spec/javascript/components/lease_ups/utils/leaseUpRequestUtils.test.js
+++ b/spec/javascript/components/lease_ups/utils/leaseUpRequestUtils.test.js
@@ -181,7 +181,8 @@ describe('leaseUpActions', () => {
         residence_address: '',
         status_last_updated: '2020-05-28T21:23:06.000+0000',
         total_household_size: 1,
-        sub_status: 'Approval letter sent'
+        sub_status: 'Approval letter sent',
+        sub_status_label: 'Approval letter sent'
       }
 
       const expectedResults = { records: [expectedRowData], pages: 10 }


### PR DESCRIPTION
## Description

Display substatus for FCFS in lease up application table. Fixes a bug introduced in this [PR](https://github.com/SFDigitalServices/sf-dahlia-lap/pull/769).

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3956

## Before requesting eng review

### Version Control

- [ ] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [ ] all automated code checks pass (linting, tests, coverage, etc.)
- [x] if the PR is a bugfix, there are tests and logs around the bug

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag
