### PR TITLE
feat: DAH-3957 reordering comment dropdown options

### DIFF
--- a/app/javascript/utils/statusUtils.js
+++ b/app/javascript/utils/statusUtils.js
@@ -28,15 +28,15 @@ export const LEASE_UP_STATUS_OPTIONS = [
 
 export const LEASE_UP_STATUSES = [
   {
-    value: 'Processing',
-    label: 'Processing',
-    statusClassName: 'is-processing',
-    commentRequired: true
-  },
-  {
     value: 'Outreach',
     label: 'Outreach',
     statusClassName: 'is-outreached',
+    commentRequired: true
+  },
+  {
+    value: 'Processing',
+    label: 'Processing',
+    statusClassName: 'is-processing',
     commentRequired: true
   },
   { value: 'Withdrawn', label: 'Withdrawn', statusClassName: 'is-withdrawn' },

--- a/spec/javascript/utils/statusUtils.test.js
+++ b/spec/javascript/utils/statusUtils.test.js
@@ -1,0 +1,20 @@
+import { LEASE_UP_STATUSES } from 'utils/statusUtils'
+
+describe('statusUtils', () => {
+  describe('LEASE_UP_STATUSES', () => {
+    test('should have the correct order of status options', () => {
+      const expectedOrder = [
+        'Outreach',
+        'Processing',
+        'Withdrawn',
+        'Appealed',
+        'Waitlisted',
+        'Disqualified',
+        'Approved',
+        'Lease Signed'
+      ]
+      const actualOrder = LEASE_UP_STATUSES.map((status) => status.value)
+      expect(actualOrder).toEqual(expectedOrder)
+    })
+  })
+})


### PR DESCRIPTION
## Description

`Outreach` should be the first option in the field update comment dropdown

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3957

## Before requesting eng review

### Version Control

- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [ ] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag
