### PR TITLE
feat: DAH-3986 disable i2a for fcfs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,8 +13,6 @@ class ApplicationController < ActionController::Base
 
   rescue_from Force::RecordNotFound, with: :not_found
 
-  INCLUSIONARY_RENTAL = 'IH-RENTAL'
-
   def not_found
     render '404', status: 404
   end
@@ -37,7 +35,9 @@ class ApplicationController < ActionController::Base
     return unless lease_up_page
 
     @listing = soql_listing_service.listing(params[:lease_up_id])
-    @show_invite_to_apply_feedback_banner = @listing.program_type == INCLUSIONARY_RENTAL && ENV['BANNER_INVITE_TO_APPLY_FEEDBACK'] == 'true'
+    @show_invite_to_apply_feedback_banner = @listing.program_type == Force::Listing::PROGRAM_TYPE_INCLUSIONARY_RENTAL &&
+                                            @listing.listing_type != Force::Listing::LISTING_TYPE_FIRST_COME_FIRST_SERVED &&
+                                            ENV['BANNER_INVITE_TO_APPLY_FEEDBACK'] == 'true'
   end
 
   def soql_listing_service

--- a/app/javascript/utils/consts.js
+++ b/app/javascript/utils/consts.js
@@ -1,2 +1,4 @@
 export const LISTING_TYPE_FIRST_COME_FIRST_SERVED = 'First Come, First Served'
+export const PROGRAM_TYPE_INCLUSIONARY_RENTAL = 'IH-RENTAL'
+
 export const UNIT_STATUS_AVAILABLE = 'Available'

--- a/app/javascript/utils/inviteApplyEmail.js
+++ b/app/javascript/utils/inviteApplyEmail.js
@@ -1,11 +1,10 @@
+import { PROGRAM_TYPE_INCLUSIONARY_RENTAL, LISTING_TYPE_FIRST_COME_FIRST_SERVED } from './consts'
 import {
   LEASE_UP_SUBSTATUS_OPTIONS,
   LEASE_UP_SUBSTATUSES,
   LEASE_UP_STATUS_OPTIONS,
   LEASE_UP_STATUSES
 } from './statusUtils'
-
-const INCLUSIONARY_RENTAL = 'IH-RENTAL'
 
 export const I2A_FEATURE_FLAG = 'partners.inviteToApply'
 
@@ -18,7 +17,12 @@ export const INVITE_APPLY_EMAIL_OPTIONS = [
 ]
 
 export const IsInviteToApplyEnabledForListing = (listing, i2aFlag) => {
-  return i2aFlag && listing && listing.program_type === INCLUSIONARY_RENTAL
+  return (
+    i2aFlag &&
+    listing &&
+    listing.program_type === PROGRAM_TYPE_INCLUSIONARY_RENTAL &&
+    listing.listing_type !== LISTING_TYPE_FIRST_COME_FIRST_SERVED
+  )
 }
 
 export const getLeaseUpSubstatusOptions = (isInviteApplyEnabled) => {

--- a/app/models/force/listing.rb
+++ b/app/models/force/listing.rb
@@ -89,6 +89,7 @@ module Force
     ].freeze
 
     LISTING_TYPE_FIRST_COME_FIRST_SERVED = 'First Come, First Served'
+    PROGRAM_TYPE_INCLUSIONARY_RENTAL = 'IH-RENTAL'
 
     def map_list_to_domain(domain_fields, list_domain_field_name, force_class)
       return unless domain_fields[list_domain_field_name]

--- a/spec/controllers/listings/lease_ups/applications_controller_spec.rb
+++ b/spec/controllers/listings/lease_ups/applications_controller_spec.rb
@@ -22,6 +22,22 @@ RSpec.describe Listings::LeaseUps::ApplicationsController, type: :controller do
         expect(response.body).to include('Sending emails from DAHLIA is new ')
         expect(response).to have_http_status(:success)
       end
+
+      it 'should not show i2a banner for First Come, First Served IH-RENTAL listings' do
+        # Mock the listing to be IH-RENTAL but FCFS
+        fcfs_listing = double('Listing',
+                              program_type: 'IH-RENTAL',
+                              listing_type: 'First Come, First Served')
+
+        allow_any_instance_of(Listings::LeaseUps::ApplicationsController)
+          .to receive(:soql_listing_service)
+          .and_return(double(listing: fcfs_listing))
+
+        get :index, params: { lease_up_id: 'test-fcfs-id' }
+
+        expect(assigns(:show_invite_to_apply_feedback_banner)).to be false
+        expect(response).to have_http_status(:success)
+      end
     end
 
     context 'when BANNER_INVITE_TO_APPLY_FEEDBACK is false' do

--- a/spec/controllers/listings/lease_ups/applications_controller_spec.rb
+++ b/spec/controllers/listings/lease_ups/applications_controller_spec.rb
@@ -22,22 +22,6 @@ RSpec.describe Listings::LeaseUps::ApplicationsController, type: :controller do
         expect(response.body).to include('Sending emails from DAHLIA is new ')
         expect(response).to have_http_status(:success)
       end
-
-      it 'should not show i2a banner for First Come, First Served IH-RENTAL listings' do
-        # Mock the listing to be IH-RENTAL but FCFS
-        fcfs_listing = double('Listing',
-                              program_type: 'IH-RENTAL',
-                              listing_type: 'First Come, First Served')
-
-        allow_any_instance_of(Listings::LeaseUps::ApplicationsController)
-          .to receive(:soql_listing_service)
-          .and_return(double(listing: fcfs_listing))
-
-        get :index, params: { lease_up_id: 'test-fcfs-id' }
-
-        expect(assigns(:show_invite_to_apply_feedback_banner)).to be false
-        expect(response).to have_http_status(:success)
-      end
     end
 
     context 'when BANNER_INVITE_TO_APPLY_FEEDBACK is false' do

--- a/spec/javascript/utils/inviteApplyEmail.test.js
+++ b/spec/javascript/utils/inviteApplyEmail.test.js
@@ -1,0 +1,50 @@
+import { IsInviteToApplyEnabledForListing } from 'utils/inviteApplyEmail'
+
+describe('IsInviteToApplyEnabledForListing', () => {
+  const mockListing = {
+    program_type: 'IH-RENTAL',
+    listing_type: 'Lottery'
+  }
+
+  const mockFcfsListing = {
+    program_type: 'IH-RENTAL',
+    listing_type: 'First Come, First Served'
+  }
+
+  const mockNonIhRentalListing = {
+    program_type: 'SOME-OTHER-TYPE',
+    listing_type: 'Lottery'
+  }
+
+  describe('when feature flag is enabled', () => {
+    const i2aFlag = true
+
+    it('returns true for IH-RENTAL listings that are not First Come, First Served', () => {
+      expect(IsInviteToApplyEnabledForListing(mockListing, i2aFlag)).toBe(true)
+    })
+
+    it('returns false for IH-RENTAL listings that are First Come, First Served', () => {
+      expect(IsInviteToApplyEnabledForListing(mockFcfsListing, i2aFlag)).toBe(false)
+    })
+
+    it('returns false for non-IH-RENTAL listings', () => {
+      expect(IsInviteToApplyEnabledForListing(mockNonIhRentalListing, i2aFlag)).toBe(false)
+    })
+  })
+
+  describe('when feature flag is disabled', () => {
+    const i2aFlag = false
+
+    it('returns false for IH-RENTAL listings that are not First Come, First Served', () => {
+      expect(IsInviteToApplyEnabledForListing(mockListing, i2aFlag)).toBe(false)
+    })
+
+    it('returns false for IH-RENTAL listings that are First Come, First Served', () => {
+      expect(IsInviteToApplyEnabledForListing(mockFcfsListing, i2aFlag)).toBe(false)
+    })
+
+    it('returns false for non-IH-RENTAL listings', () => {
+      expect(IsInviteToApplyEnabledForListing(mockNonIhRentalListing, i2aFlag)).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Description

Disable the invite to apply button and email feedback banner for first come, first served listings

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3986

## Before requesting eng review

### Version Control

- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Review instructions

- [ ] instructions specify which environment(s) it applies to
- [ ] instructions work for PA testers
- [ ] instructions have already been performed at least once

### Request eng review

- [ ] PR has `needs review` label
- [ ] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag
