### PR TITLE
fix: DAH-4096 i2x url validation allows for spaces

### DIFF
--- a/app/javascript/utils/form/validations.js
+++ b/app/javascript/utils/form/validations.js
@@ -122,9 +122,8 @@ const isPresent = (value) => {
 const isValidUrl = (value) => {
   try {
     if (/\s/.test(value)) return false // URLs cannot contain spaces
-    // eslint-disable-next-line no-new
-    new URL(value)
-    return true
+    const url = new URL(value)
+    return url.protocol === 'http:' || url.protocol === 'https:'
   } catch (err) {
     return false
   }

--- a/app/javascript/utils/form/validations.js
+++ b/app/javascript/utils/form/validations.js
@@ -121,6 +121,7 @@ const isPresent = (value) => {
 
 const isValidUrl = (value) => {
   try {
+    if (/\s/.test(value)) return false // URLs cannot contain spaces
     // eslint-disable-next-line no-new
     new URL(value)
     return true

--- a/spec/javascript/utils/form/validations.test.js
+++ b/spec/javascript/utils/form/validations.test.js
@@ -27,6 +27,11 @@ describe('validate', () => {
       test('is invalid url', () => {
         expect(validate.isValidUrl(VALIDATION_MSG)('foo')).toEqual(VALIDATION_MSG)
       })
+      test('is url containing spaces', () => {
+        expect(validate.isValidUrl(VALIDATION_MSG)('https://www.sf.gov/some path')).toEqual(
+          VALIDATION_MSG
+        )
+      })
     })
   })
   describe('isOldEnough', () => {

--- a/spec/javascript/utils/form/validations.test.js
+++ b/spec/javascript/utils/form/validations.test.js
@@ -22,10 +22,19 @@ describe('validate', () => {
       test('is valid url', () => {
         expect(validate.isValidUrl(VALIDATION_MSG)('https://www.sf.gov')).toBeUndefined()
       })
+      test('is valid url with http protocol', () => {
+        expect(validate.isValidUrl(VALIDATION_MSG)('http://www.sf.gov')).toBeUndefined()
+      })
     })
     describe('fails validation', () => {
       test('is invalid url', () => {
         expect(validate.isValidUrl(VALIDATION_MSG)('foo')).toEqual(VALIDATION_MSG)
+      })
+      test('is url without protocol', () => {
+        expect(validate.isValidUrl(VALIDATION_MSG)('www.sf.gov')).toEqual(VALIDATION_MSG)
+      })
+      test('is url with wrong protocol', () => {
+        expect(validate.isValidUrl(VALIDATION_MSG)('ftp://www.sf.gov')).toEqual(VALIDATION_MSG)
       })
       test('is url containing spaces', () => {
         expect(validate.isValidUrl(VALIDATION_MSG)('https://www.sf.gov/some path')).toEqual(


### PR DESCRIPTION
## Description

Add a check for space in url validation.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-4096

## Before requesting eng review

### Version Control

- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] if the PR is a bugfix, there are tests and logs around the bug

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag
