### PR TITLE
chore: DAH-4013 Cleanup temp.partners.inviteToApply.statuses Flag

### DIFF
--- a/cypress/support/utils.js
+++ b/cypress/support/utils.js
@@ -45,14 +45,6 @@ export const interceptInviteToApplyFlag = (listingId) => {
               value: listingId
             }
           }
-        },
-        {
-          name: 'temp.partners.inviteToApply.statuses',
-          enabled: true,
-          variant: {
-            name: 'enabled_listing',
-            enabled: true
-          }
         }
       ]
     }


### PR DESCRIPTION
## Description

Cleans up usage of `temp.partners.inviteToApply.statuses`

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-4013

## Before requesting eng review

### Version Control

- [ ] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [ ] if the PR is a bugfix, there are tests and logs around the bug

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [x] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [ ] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag
