### PR TITLE
fix: DAH-4235 Contact Info incorrectly flagged as updated when the new contact info field value is null

### DIFF
--- a/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
+++ b/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
@@ -39,7 +39,7 @@ export const isContactUpdated = (shortForm) => {
   const fieldsToCheck = ['email', 'phone', 'phone_type', 'second_phone', 'second_phone_type']
 
   for (const field of fieldsToCheck) {
-    if (contactInfo?.[field] && applicant?.[field] !== contactInfo[field]) {
+    if (contactInfo?.[field] != null && applicant?.[field] !== contactInfo?.[field]) {
       return true
     }
   }

--- a/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
+++ b/app/javascript/components/supplemental_application/SupplementalApplicationPage.js
@@ -39,7 +39,7 @@ export const isContactUpdated = (shortForm) => {
   const fieldsToCheck = ['email', 'phone', 'phone_type', 'second_phone', 'second_phone_type']
 
   for (const field of fieldsToCheck) {
-    if (applicant?.[field] !== contactInfo?.[field]) {
+    if (contactInfo?.[field] && applicant?.[field] !== contactInfo[field]) {
       return true
     }
   }

--- a/spec/javascript/components/supplemental_application/SupplementalApplicationPage.test.js
+++ b/spec/javascript/components/supplemental_application/SupplementalApplicationPage.test.js
@@ -270,6 +270,29 @@ describe('isContactUpdated', () => {
   test('returns false when shortForm is missing', () => {
     expect(isContactUpdated(undefined)).toBe(false)
   })
+
+  test('returns false when a contactInfo value is null', () => {
+    const shortForm = {
+      application: {
+        applicant: {
+          email: 'test@example.com',
+          phone: '415-111-1111',
+          phone_type: 'Cell',
+          second_phone: '415-222-2222',
+          second_phone_type: 'Home'
+        },
+        contact_info: {
+          email: null,
+          phone: null,
+          phone_type: null,
+          second_phone: null,
+          second_phone_type: null
+        }
+      }
+    }
+
+    expect(isContactUpdated(shortForm)).toBe(false)
+  })
 })
 
 describe('SupplementalApplicationPage', () => {


### PR DESCRIPTION
## Description

Add guard against null so that applications are not incorrectly flagged as updated

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-4235

## Before requesting eng review

### Version Control

- [x] branch name contains the Jira ticket number
- [x] PR name follows `type: TICKET-NUMBER Description` format, use `DAH-000` if it does not need a ticket
- [ ] PR name follows `urgent: Description` format if it is urgent and does not need a ticket

### Code quality

- [x] [the set of changes is small](https://google.github.io/eng-practices/review/developer/small-cls.html#what-is-small)
- [x] all automated code checks pass (linting, tests, coverage, etc.)
- [x] if the PR is a bugfix, there are tests and logs around the bug

### Review instructions

- [x] instructions specify which environment(s) it applies to
- [x] instructions work for PA testers
- [ ] instructions have already been performed at least once

### Request eng review

- [x] PR has `needs review` label
- [x] Use `Housing Eng` group to automatically assign reviewers, and/or assign specific engineers
- [ ] If time sensitive, notify engineers in Slack

## Before merging

### Request product acceptance (PA) testing

- [x] PA tested in the review environment (use `needs product acceptance` label)
- [ ] if PA testing cannot be done, changes are behind a feature flag
