### PR TITLE
fix: DAH-3752 lottery results missing applications on listings without preferences

### DIFF
--- a/app/assets/stylesheets/lottery-results-pdf-generator.css
+++ b/app/assets/stylesheets/lottery-results-pdf-generator.css
@@ -345,3 +345,28 @@ kbd + kbd {
     padding-right: 0;
   }
 }
+
+#lottery-results-warnings {
+  margin: 1rem 2rem 0 2rem;
+  padding: 0.75rem 1rem;
+}
+
+#lottery-results-warnings ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  list-style: disc;
+}
+
+#lottery-results-warnings li {
+  margin-bottom: 0.25rem;
+}
+
+@media print {
+  /* the warnings are for whoever is reading the page, not for the printed
+     results: they can be expected for a given listing and known to be safe to
+     ignore.  react-to-print already renders only the results component, this
+     covers printing the page directly from the browser. */
+  #lottery-results-warnings {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/lottery-results-pdf-generator.css
+++ b/app/assets/stylesheets/lottery-results-pdf-generator.css
@@ -259,20 +259,30 @@ label > input {
 #lottery-results-pdf-th-h4,
 #lottery-results-pdf-column h5 {
   margin: 0.5rem 0 0.5rem 2rem;
-  flex-wrap: wrap;
-  display: flex;
+  /* grid rather than flex so that a title or subtitle wrapping to an extra
+     line grows its cell instead of overflowing a fixed height into the results
+     below.  the heights stay even across columns because each of these rows is
+     a single table row, which sizes to its tallest cell. */
+  display: grid;
   font-family: Verdana, sans-serif;
 }
 
 #lottery-results-pdf-th-h4 {
-  height: 2em;
-  align-content: flex-end;
+  min-height: 2em;
+  align-content: end;
+}
+
+/* sit the titles on the bottom of the header row, so that the last line of a
+   title that wrapped lines up with a title that didn't */
+#lottery-results-pdf-th {
+  vertical-align: bottom;
 }
 
 #lottery-results-pdf-column h5 {
   font-size: 0.75rem;
   font-weight: normal;
-  height: 2.5em;
+  min-height: 2.5em;
+  align-content: start;
 }
 
 #lottery-results-pdf-row ol {

--- a/app/javascript/components/lease_ups/lottery_results_page/LotteryBuckets.js
+++ b/app/javascript/components/lease_ups/lottery_results_page/LotteryBuckets.js
@@ -42,13 +42,22 @@ const LotteryBucketResult = ({ id, preferenceResults }) => {
 }
 
 export const LotteryBuckets = ({ buckets = [] }) => {
-  const maxWidth = `${buckets.length * ColumnMaxWidth}ch`
   const titleCells = []
   const subtitleCells = []
   const resultCells = []
 
   buckets.forEach((bucket) => {
-    const { id, subtitle, shortName } = Preferences[bucket.shortCode]
+    const preference = Preferences[bucket.shortCode]
+
+    // an unmapped short code used to throw here and blank the entire page, so
+    // skip just the offending column instead
+    if (!preference) {
+      console.warn(`Unknown preference: ${bucket.shortCode}`)
+
+      return
+    }
+
+    const { id, subtitle, shortName } = preference
 
     titleCells.push(<LotteryBucketTitle key={id} shortName={shortName} />)
 
@@ -59,7 +68,9 @@ export const LotteryBuckets = ({ buckets = [] }) => {
 
   // to allow the table to expand, up to a point, when there's more room, we
   // have to put it inside a section that has a max-width set on it, based on
-  // the number of columns.  we can't calculate that in CSS, unfortunately.
+  // the number of columns actually rendered.  we can't calculate that in CSS,
+  // unfortunately.
+  const maxWidth = `${titleCells.length * ColumnMaxWidth}ch`
   return (
     <div style={{ maxWidth }} id='lottery-results-section'>
       <table id='lottery-results-table'>

--- a/app/javascript/components/lease_ups/lottery_results_page/LotteryManager.js
+++ b/app/javascript/components/lease_ups/lottery_results_page/LotteryManager.js
@@ -15,18 +15,36 @@ const LotteryManager = ({ applications, listing, withLotteryResultApi }) => {
     removeAfterPrint: true
   })
 
-  // process applications into buckets
+  // process applications into buckets, collecting anything the housing team
+  // should look at before sharing the results
+  const warnings = []
   let processedBuckets = null
   if (withLotteryResultApi && applications) {
-    processedBuckets = massageLotteryBuckets(applications)
+    processedBuckets = massageLotteryBuckets(applications, warnings)
   } else if (applications) {
-    processedBuckets = processLotteryBuckets(applications)
+    processedBuckets = processLotteryBuckets(applications, warnings)
   }
 
   return (
     <>
       {processedBuckets ? (
         <>
+          {warnings.length > 0 && (
+            // deliberately outside the printed component: these may be known
+            // and ignorable for a given listing, and shouldn't reach the PDF
+            <div id='lottery-results-warnings' className='alert-notice alert'>
+              <p className='t-tiny c-alert margin-bottom'>
+                Check these lottery results before sharing them
+              </p>
+              <ul>
+                {warnings.map((warning) => (
+                  <li key={warning} className='t-tiny c-steel'>
+                    {warning}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
           <div id='save-lottery-results-button-container'>
             <button
               onClick={() => {

--- a/app/javascript/components/lease_ups/lottery_results_page/LotteryResultsPdfGenerator.js
+++ b/app/javascript/components/lease_ups/lottery_results_page/LotteryResultsPdfGenerator.js
@@ -27,8 +27,11 @@ const LotteryResultsPdfGenerator = (props) => {
   const [applications, setApplications] = useState()
   const [listing, setListing] = useState()
 
-  const withLotteryResultApi = () =>
-    new URLSearchParams(window.location.search).has('withLotteryResultApi')
+  // the LotteryResult API is the source of truth: the older preference-record
+  // query only returns applications that receive a preference, so it omits the
+  // general lottery entirely on most listings.  ?legacy is a temporary escape
+  // hatch back to that query while the two are compared.
+  const withLotteryResultApi = () => !new URLSearchParams(window.location.search).has('legacy')
 
   useEffect(() => {
     if (withLotteryResultApi()) {

--- a/app/javascript/components/lease_ups/lottery_results_page/utils/preferences.js
+++ b/app/javascript/components/lease_ups/lottery_results_page/utils/preferences.js
@@ -18,10 +18,10 @@ const Units40Pct = 'Up to 40% of units'
 const Units100PctRemaining = 'Up to 100% of remaining units'
 const UnitsRemaining = 'Remaining units'
 
-// TODO: confirm the official subtitle copy for ADHP / RB_AHP / AG / Custom with
-// the housing team.  These render into the printed PDF and are editable in the
-// UI, so an empty default is safe but not ideal.
-const SubtitleTBD = ''
+// preferences with no unit set-aside of their own are open to all the units.
+// the subtitle is editable in the UI, so a listing that does set one aside can
+// still be corrected by hand before printing.
+const NoSetAside = Units100Pct
 
 export const GENERAL_LOTTERY_ID = 'General List'
 export const UNFILTERED_ID = 'Unfiltered Rank'
@@ -41,7 +41,7 @@ const PreferenceDefinitions = [
     id: 'RTR-H',
     name: 'Right to Return - Hunters View',
     shortName: 'RTR',
-    subtitle: SubtitleTBD
+    subtitle: NoSetAside
   },
   {
     id: 'V-COP',
@@ -87,53 +87,53 @@ const PreferenceDefinitions = [
   {
     id: 'V-ADHP',
     name: 'Veteran with Anti-Displacement Housing Preference (V-ADHP)',
-    subtitle: SubtitleTBD
+    subtitle: NoSetAside
   },
   {
     id: 'ADHP',
     name: 'Anti-Displacement Housing Preference (ADHP)',
-    subtitle: SubtitleTBD
+    subtitle: NoSetAside
   },
   {
     id: 'V-RB_AHP',
     name: 'Veteran with Rent Burdened / Assisted Housing Preference (V-RB_AHP)',
     shortName: 'V-RB/AHP',
-    subtitle: SubtitleTBD
+    subtitle: NoSetAside
   },
   {
     id: 'RB_AHP',
     name: 'Rent Burdened / Assisted Housing Preference',
     shortName: 'RB/AHP',
-    subtitle: SubtitleTBD
+    subtitle: NoSetAside
   },
   {
     id: 'V-AG',
     name: 'Veteran with Alice Griffith Housing Development Resident (V-AG)',
     shortName: 'V-Alice Griffith',
-    subtitle: SubtitleTBD
+    subtitle: NoSetAside
   },
   {
     id: 'AG',
     name: 'Alice Griffith Housing Development Resident',
     shortName: 'Alice Griffith',
-    subtitle: SubtitleTBD
+    subtitle: NoSetAside
   },
   {
     id: 'DFR',
     name: 'DALP First Responders',
     shortName: 'First Responders',
-    subtitle: SubtitleTBD
+    subtitle: NoSetAside
   },
   {
     id: 'DSE',
     name: 'DALP Educators',
     shortName: 'Educator',
-    subtitle: SubtitleTBD
+    subtitle: NoSetAside
   },
   {
     id: 'Custom',
     name: 'Custom',
-    subtitle: SubtitleTBD
+    subtitle: NoSetAside
   },
   {
     id: GENERAL_LOTTERY_ID,

--- a/app/javascript/components/lease_ups/lottery_results_page/utils/preferences.js
+++ b/app/javascript/components/lease_ups/lottery_results_page/utils/preferences.js
@@ -1,200 +1,174 @@
-export const Preferences = {
-  DFR: {
+// Canonical lottery preference definitions.
+//
+// `id` MUST match the Salesforce `Custom_Preference_Type__c` /
+// `Record_Type_For_App_Preferences__c` value, since that's what the lottery
+// results records are bucketed by.  Keep this list in sync with
+// `Force::Preference::PREFERENCE_TYPES` in app/models/force/preference.rb.
+//
+// Salesforce is inconsistent about whether a preference name includes its
+// abbreviation in parens (e.g. both "Certificate of Preference (COP)" and
+// "Certificate of Preference" appear on real records), so each preference is
+// registered under its id, its full name, AND its name with the parenthetical
+// stripped.  Missing one of those aliases silently drops applicants from the
+// results, which is what this indexing is guarding against.
+
+const Units100Pct = 'Up to 100% of units'
+const Units20Pct = 'Up to 20% of units'
+const Units40Pct = 'Up to 40% of units'
+const Units100PctRemaining = 'Up to 100% of remaining units'
+const UnitsRemaining = 'Remaining units'
+
+// TODO: confirm the official subtitle copy for ADHP / RB_AHP / AG / Custom with
+// the housing team.  These render into the printed PDF and are editable in the
+// UI, so an empty default is safe but not ideal.
+const SubtitleTBD = ''
+
+export const GENERAL_LOTTERY_ID = 'General List'
+export const UNFILTERED_ID = 'Unfiltered Rank'
+
+// Preferences that always get a column in the results, even when empty, to
+// preserve the historical shape of the printed PDF.
+export const AlwaysVisiblePreferenceIDs = ['COP', 'DTHP', 'NRHP', 'L_W']
+
+const PreferenceDefinitions = [
+  {
+    id: 'V-COP',
+    name: 'Veteran with Certificate of Preference (V-COP)',
+    subtitle: Units100Pct
+  },
+  {
+    id: 'COP',
+    name: 'Certificate of Preference (COP)',
+    subtitle: Units100Pct
+  },
+  {
+    id: 'V-DTHP',
+    name: 'Veteran with Displaced Tenant Housing Preference (V-DTHP)',
+    subtitle: Units20Pct
+  },
+  {
+    id: 'DTHP',
+    name: 'Displaced Tenant Housing Preference (DTHP)',
+    subtitle: Units20Pct
+  },
+  {
+    id: 'V-NRHP',
+    name: 'Veteran with Neighborhood Resident Housing Preference (V-NRHP)',
+    subtitle: Units40Pct
+  },
+  {
+    id: 'NRHP',
+    name: 'Neighborhood Resident Housing Preference (NRHP)',
+    subtitle: Units40Pct
+  },
+  {
+    id: 'V-L_W',
+    name: 'Veteran with Live or Work in San Francisco Preference (V-L_W)',
+    subtitle: Units100PctRemaining
+  },
+  {
+    id: 'L_W',
+    name: 'Live or Work in San Francisco Preference',
+    shortName: 'Live/Work',
+    subtitle: Units100PctRemaining
+  },
+  {
+    id: 'V-ADHP',
+    name: 'Veteran with Anti-Displacement Housing Preference (V-ADHP)',
+    subtitle: SubtitleTBD
+  },
+  {
+    id: 'ADHP',
+    name: 'Anti-Displacement Housing Preference (ADHP)',
+    subtitle: SubtitleTBD
+  },
+  {
+    id: 'V-RB_AHP',
+    name: 'Veteran with Rent Burdened / Assisted Housing Preference (V-RB_AHP)',
+    shortName: 'V-RB/AHP',
+    subtitle: SubtitleTBD
+  },
+  {
+    id: 'RB_AHP',
+    name: 'Rent Burdened / Assisted Housing Preference',
+    shortName: 'RB/AHP',
+    subtitle: SubtitleTBD
+  },
+  {
+    id: 'V-AG',
+    name: 'Veteran with Alice Griffith Housing Development Resident (V-AG)',
+    shortName: 'V-Alice Griffith',
+    subtitle: SubtitleTBD
+  },
+  {
+    id: 'AG',
+    name: 'Alice Griffith Housing Development Resident',
+    shortName: 'Alice Griffith',
+    subtitle: SubtitleTBD
+  },
+  {
     id: 'DFR',
     name: 'DALP First Responders',
-    subtitle: 'subtitle',
     shortName: 'First Responders',
-    index: 0,
-    isVeteran: false,
-    relatedPrefID: ''
+    subtitle: SubtitleTBD
   },
-  DSE: {
+  {
     id: 'DSE',
     name: 'DALP Educators',
-    subtitle: 'subtitle',
     shortName: 'Educator',
-    index: 0,
-    isVeteran: false,
-    relatedPrefID: ''
+    subtitle: SubtitleTBD
   },
-  'V-COP': {
-    id: 'V-COP',
-    name: 'Veteran with Certificate of Preference',
-    subtitle: 'Up to 100% of units',
-    shortName: 'V-COP',
-    index: 0,
-    isVeteran: true,
-    relatedPrefID: 'COP'
+  {
+    id: 'Custom',
+    name: 'Custom',
+    subtitle: SubtitleTBD
   },
-  'Veteran with Certificate of Preference': {
-    id: 'V-COP',
-    name: 'Veteran with Certificate of Preference',
-    subtitle: 'Up to 100% of units',
-    shortName: 'V-COP',
-    index: 0,
-    isVeteran: true,
-    relatedPrefID: 'COP'
-  },
-  COP: {
-    id: 'COP',
-    name: 'Certificate of Preference (COP)',
-    subtitle: 'Up to 100% of units',
-    shortName: 'COP',
-    index: 1,
-    isVeteran: false,
-    relatedPrefID: ''
-  },
-  'Certificate of Preference (COP)': {
-    id: 'COP',
-    name: 'Certificate of Preference (COP)',
-    subtitle: 'Up to 100% of units',
-    shortName: 'COP',
-    index: 1,
-    isVeteran: false,
-    relatedPrefID: ''
-  },
-  'V-DTHP': {
-    id: 'V-DTHP',
-    name: 'Veteran with Displaced Tenant Housing Preference',
-    subtitle: 'Up to 20% of units',
-    shortName: 'V-DTHP',
-    index: 2,
-    isVeteran: true,
-    relatedPrefID: 'DTHP'
-  },
-  'Veteran with Displaced Tenant Housing Preference': {
-    id: 'V-DTHP',
-    name: 'Veteran with Displaced Tenant Housing Preference',
-    subtitle: 'Up to 20% of units',
-    shortName: 'V-DTHP',
-    index: 2,
-    isVeteran: true,
-    relatedPrefID: 'DTHP'
-  },
-  DTHP: {
-    id: 'DTHP',
-    name: 'Displaced Tenant Housing Preference',
-    subtitle: 'Up to 20% of units',
-    shortName: 'DTHP',
-    index: 3,
-    isVeteran: false,
-    relatedPrefID: ''
-  },
-  'Displaced Tenant Housing Preference': {
-    id: 'DTHP',
-    name: 'Displaced Tenant Housing Preference',
-    subtitle: 'Up to 20% of units',
-    shortName: 'DTHP',
-    index: 3,
-    isVeteran: false,
-    relatedPrefID: ''
-  },
-  'V-NRHP': {
-    id: 'V-NRHP',
-    name: 'Veteran with Neighborhood Resident Housing Preference',
-    subtitle: 'Up to 40% of units',
-    shortName: 'V-NRHP',
-    index: 4,
-    isVeteran: true,
-    relatedPrefID: 'NRHP'
-  },
-  'Veteran with Neighborhood Resident Housing Preference': {
-    id: 'V-NRHP',
-    name: 'Veteran with Neighborhood Resident Housing Preference',
-    subtitle: 'Up to 40% of units',
-    shortName: 'V-NRHP',
-    index: 4,
-    isVeteran: true,
-    relatedPrefID: 'NRHP'
-  },
-  NRHP: {
-    id: 'NRHP',
-    name: 'Neighborhood Resident Housing Preference',
-    subtitle: 'Up to 40% of units',
-    shortName: 'NRHP',
-    index: 5,
-    isVeteran: false,
-    relatedPrefID: ''
-  },
-  'Neighborhood Resident Housing Preference': {
-    id: 'NRHP',
-    name: 'Neighborhood Resident Housing Preference',
-    subtitle: 'Up to 40% of units',
-    shortName: 'NRHP',
-    index: 5,
-    isVeteran: false,
-    relatedPrefID: ''
-  },
-  'V-L_W': {
-    id: 'V-L_W',
-    name: 'Veteran with Live or Work in San Francisco Preference',
-    subtitle: 'Up to 100% of remaining units',
-    shortName: 'V-L_W',
-    index: 6,
-    isVeteran: true,
-    relatedPrefID: 'L_W'
-  },
-  'Veteran with Live or Work in San Francisco Preference': {
-    id: 'V-L_W',
-    name: 'Veteran with Live or Work in San Francisco Preference',
-    subtitle: 'Up to 100% of remaining units',
-    shortName: 'V-L_W',
-    index: 6,
-    isVeteran: true,
-    relatedPrefID: 'L_W'
-  },
-  L_W: {
-    id: 'L_W',
-    name: 'Live or Work in San Francisco Preference',
-    subtitle: 'Up to 100% of remaining units',
-    shortName: 'Live/Work',
-    index: 7,
-    isVeteran: false,
-    relatedPrefID: ''
-  },
-  'Live or Work in San Francisco Preference': {
-    id: 'L_W',
-    name: 'Live or Work in San Francisco Preference',
-    subtitle: 'Up to 100% of remaining units',
-    shortName: 'Live/Work',
-    index: 7,
-    isVeteran: false,
-    relatedPrefID: ''
-  },
-  'General List': {
-    id: 'General List',
+  {
+    id: GENERAL_LOTTERY_ID,
     name: 'generalLottery',
-    subtitle: 'Remaining units',
-    shortName: 'General List',
-    index: 8,
-    isVeteran: false,
-    relatedPrefID: ''
+    subtitle: UnitsRemaining
   },
-  generalLottery: {
-    id: 'General List',
-    name: 'generalLottery',
-    subtitle: 'Remaining units',
-    shortName: 'General List',
-    index: 8,
-    isVeteran: false,
-    relatedPrefID: ''
-  },
-  'Unfiltered Rank': {
-    id: 'Unfiltered Rank',
+  {
+    id: UNFILTERED_ID,
     name: 'Unfiltered',
-    subtitle: 'Ticket #',
-    shortName: 'Unfiltered Rank',
-    index: 9,
-    isVeteran: false,
-    relatedPrefID: ''
-  },
-  Unfiltered: {
-    id: 'Unfiltered Rank',
-    name: 'Unfiltered',
-    subtitle: 'Ticket #',
-    shortName: 'Unfiltered Rank',
-    index: 9,
-    isVeteran: false,
-    relatedPrefID: ''
+    subtitle: 'Ticket #'
   }
-}
+]
+
+// strip a trailing parenthetical abbreviation, e.g.
+// "Certificate of Preference (COP)" -> "Certificate of Preference"
+const nameWithoutID = (name) => name.replace(/ \(.+$/, '')
+
+export const Preferences = PreferenceDefinitions.reduce(
+  (result, { id, name, subtitle, shortName = id }, index) => {
+    const isVeteran = id.startsWith('V-')
+    const preference = {
+      id,
+      name,
+      subtitle,
+      shortName,
+      index,
+      isVeteran,
+      relatedPrefID: isVeteran ? id.slice(2) : ''
+    }
+
+    // make the preference reachable by id, full name, and name sans abbreviation
+    result[id] = preference
+    result[name] = preference
+    result[nameWithoutID(name)] = preference
+
+    return result
+  },
+  {}
+)
+
+// ids of the actual lottery preferences, in display order, excluding the
+// synthetic General List / Unfiltered Rank columns
+export const LotteryPreferenceIDs = PreferenceDefinitions.map(({ id }) => id).filter(
+  (id) => id !== GENERAL_LOTTERY_ID && id !== UNFILTERED_ID
+)
+
+// ids of the non-veteran lottery preferences, in display order
+export const NonVeteranPreferenceIDs = LotteryPreferenceIDs.filter(
+  (id) => !Preferences[id].isVeteran
+)

--- a/app/javascript/components/lease_ups/lottery_results_page/utils/preferences.js
+++ b/app/javascript/components/lease_ups/lottery_results_page/utils/preferences.js
@@ -31,6 +31,18 @@ export const UNFILTERED_ID = 'Unfiltered Rank'
 export const AlwaysVisiblePreferenceIDs = ['COP', 'DTHP', 'NRHP', 'L_W']
 
 const PreferenceDefinitions = [
+  // Right to Return is per-development, so each one is its own record type.
+  // Only the Hunters View code has been observed in lottery results data; other
+  // developments (Sunnydale, Potrero) presumably follow the same RTR-<letter>
+  // pattern but their codes are unconfirmed, and an unconfirmed guess here
+  // would silently mislabel a column.  An unlisted code still reaches the
+  // unfiltered rank and logs a warning, which is how this one was found.
+  {
+    id: 'RTR-H',
+    name: 'Right to Return - Hunters View',
+    shortName: 'RTR',
+    subtitle: SubtitleTBD
+  },
   {
     id: 'V-COP',
     name: 'Veteran with Certificate of Preference (V-COP)',

--- a/app/javascript/components/lease_ups/lottery_results_page/utils/processLotteryBuckets.js
+++ b/app/javascript/components/lease_ups/lottery_results_page/utils/processLotteryBuckets.js
@@ -10,6 +10,26 @@ const GENERAL_LOTTERY_KEY = 'generalLottery'
 // that they still show up in the Unfiltered Rank column rather than vanishing
 const UNKNOWN_KEY = '__unknown'
 
+// Problems worth telling the user about, rather than only the console: a
+// preference we can't map to a column, or veteran data that doesn't line up
+// with its base preference.  Callers pass an array to collect them, and the
+// page shows them above the results.  They're warnings, not errors: the
+// results still render, and for a given listing the housing team may already
+// know a message can be ignored.
+const warn = (warnings, message) => {
+  console.warn(message)
+  warnings.push(message)
+}
+
+const applicantCount = (count) => `${count} ${count === 1 ? 'application' : 'applications'}`
+
+// a preference type in Salesforce that isn't in preferences.js gets no column
+// of its own.  it needs to be added there, with a name and subtitle, before it
+// can be displayed as its own set of results.
+const unknownPreferenceWarning = (preferenceType, count) =>
+  `“${preferenceType}” isn't a preference this page can display, so its ${applicantCount(count)} ` +
+  `${count === 1 ? 'appears' : 'appear'} only in the Unfiltered Rank column.`
+
 // build a fresh set of empty buckets on every call.  these used to be
 // module-level literals that were mutated in place, which leaked results
 // between invocations.
@@ -23,8 +43,8 @@ const buildEmptyBuckets = () => {
   return buckets
 }
 
-export const groupBuckets = (applicationPreferences) => {
-  const unknownTypes = new Set()
+export const groupBuckets = (applicationPreferences, warnings = []) => {
+  const unknownTypes = {}
 
   const buckets = Object.values(applicationPreferences).reduce((acc, appPref) => {
     const cleanApp = {
@@ -41,7 +61,9 @@ export const groupBuckets = (applicationPreferences) => {
       if (acc[preferenceType]) {
         acc[preferenceType].push(cleanApp)
       } else {
-        unknownTypes.add(String(preferenceType))
+        const type = String(preferenceType)
+
+        unknownTypes[type] = (unknownTypes[type] || 0) + 1
         acc[UNKNOWN_KEY].push(cleanApp)
       }
     }
@@ -49,15 +71,9 @@ export const groupBuckets = (applicationPreferences) => {
     return acc
   }, buildEmptyBuckets())
 
-  if (unknownTypes.size) {
-    // a new preference type in Salesforce that isn't in preferences.js will end
-    // up here.  it needs to be added there to get its own results column.
-    console.warn(
-      `Unknown lottery preference type(s), omitted from preference columns: ${[
-        ...unknownTypes
-      ].join(', ')}`
-    )
-  }
+  Object.entries(unknownTypes).forEach(([type, count]) => {
+    warn(warnings, unknownPreferenceWarning(type, count))
+  })
 
   return buckets
 }
@@ -100,11 +116,16 @@ export const processUnfilteredBucket = (combinedBuckets, extraResults = []) => {
 }
 
 // fold a V-<pref> bucket into its base <pref> bucket: veterans are flagged (the
-// UI marks them with a *) and listed first.  the two sources overlap in the
-// preference-record data, where a veteran holds both a V-COP and a COP record,
-// but the LotteryResult API is not guaranteed to repeat them, so any veteran
-// missing from the base bucket is appended rather than dropped.
-const processVeteranBucket = (bucketApplications, relatedVeteranApplications) => {
+// UI marks them with a *) and listed first.  every veteran application should
+// also hold the base preference, so a veteran missing from the base bucket is a
+// data problem: it's surfaced as a warning and the applicant is kept rather
+// than dropped.
+const processVeteranBucket = (
+  bucketApplications,
+  relatedVeteranApplications,
+  bucketKey,
+  warnings = []
+) => {
   const veteranLotteryNumbers = new Set(
     relatedVeteranApplications.map(({ lottery_number: lotteryNumber }) => lotteryNumber)
   )
@@ -122,18 +143,33 @@ const processVeteranBucket = (bucketApplications, relatedVeteranApplications) =>
     }
   }
 
+  let missingFromBase = 0
+
   for (const application of relatedVeteranApplications) {
     if (!seenVeterans.has(application.lottery_number)) {
       application.isVeteran = true
       veteranApplications.push(application)
       seenVeterans.add(application.lottery_number)
+      missingFromBase += 1
     }
+  }
+
+  if (missingFromBase) {
+    const { name, shortName } = Preferences[bucketKey]
+
+    warn(
+      warnings,
+      `${applicantCount(missingFromBase)} ${missingFromBase === 1 ? 'has' : 'have'} the veteran ` +
+        `version of ${name} but not the preference itself, which shouldn't happen. ` +
+        `${missingFromBase === 1 ? "It's" : "They're"} included in the ${shortName} column, but ` +
+        'the application data may need to be checked.'
+    )
   }
 
   return [...veteranApplications, ...nonVeteranApplications]
 }
 
-export const combineVeteranBuckets = (buckets) => {
+export const combineVeteranBuckets = (buckets, warnings = []) => {
   const bucketsByKey = Object.fromEntries(buckets)
   const combinedBuckets = {}
 
@@ -163,7 +199,7 @@ export const combineVeteranBuckets = (buckets) => {
       shortCode: bucketKey,
       preferenceName: Preferences[bucketKey].shortName,
       preferenceResults: relatedVeteranApplications
-        ? processVeteranBucket(bucketApplications, relatedVeteranApplications)
+        ? processVeteranBucket(bucketApplications, relatedVeteranApplications, bucketKey, warnings)
         : bucketApplications
     }
   })
@@ -171,12 +207,12 @@ export const combineVeteranBuckets = (buckets) => {
   return combinedBuckets
 }
 
-export const processLotteryBuckets = (applicationPreferences) => {
+export const processLotteryBuckets = (applicationPreferences, warnings = []) => {
   // group application preferences into buckets by preference type
-  const buckets = groupBuckets(Object.values(applicationPreferences))
+  const buckets = groupBuckets(Object.values(applicationPreferences), warnings)
 
   // combine non-veteran and their related veteran bucket
-  const combinedBuckets = combineVeteranBuckets(Object.entries(buckets))
+  const combinedBuckets = combineVeteranBuckets(Object.entries(buckets), warnings)
 
   // add general lottery bucket
   if (buckets[GENERAL_LOTTERY_KEY]) {
@@ -195,8 +231,8 @@ export const processLotteryBuckets = (applicationPreferences) => {
 // variants kept separate.  reshape its records into the same form the
 // preference-record path produces, then run them through the same combining,
 // so both paths render identical columns.
-export const massageLotteryBuckets = (buckets) => {
-  const unknownShortCodes = new Set()
+export const massageLotteryBuckets = (buckets, warnings = []) => {
+  const unknownShortCodes = {}
   const unknownResults = []
   const resultsByShortCode = {}
   const orderByShortCode = {}
@@ -223,16 +259,18 @@ export const massageLotteryBuckets = (buckets) => {
     } else {
       // an unmapped preference gets no column of its own, but its applicants
       // still belong in the unfiltered rank
-      unknownShortCodes.add(String(shortCode))
+      const code = String(shortCode)
+
+      unknownShortCodes[code] = (unknownShortCodes[code] || 0) + results.length
       unknownResults.push(...results)
     }
   })
 
-  if (unknownShortCodes.size) {
-    console.warn(`Unknown lottery preference short code(s): ${[...unknownShortCodes].join(', ')}`)
-  }
+  Object.entries(unknownShortCodes).forEach(([shortCode, count]) => {
+    warn(warnings, unknownPreferenceWarning(shortCode, count))
+  })
 
-  const combinedBuckets = combineVeteranBuckets(Object.entries(resultsByShortCode))
+  const combinedBuckets = combineVeteranBuckets(Object.entries(resultsByShortCode), warnings)
 
   // a folded column takes its base preference's position, or the veteran
   // bucket's if that is all the listing has.  anything the API sent without an

--- a/app/javascript/components/lease_ups/lottery_results_page/utils/processLotteryBuckets.js
+++ b/app/javascript/components/lease_ups/lottery_results_page/utils/processLotteryBuckets.js
@@ -199,10 +199,18 @@ export const massageLotteryBuckets = (buckets) => {
   const unknownShortCodes = new Set()
   const unknownResults = []
   const resultsByShortCode = {}
+  const orderByShortCode = {}
 
   buckets.forEach((bucket) => {
     // the general lottery bucket comes back without a short code
     const shortCode = bucket.preferenceShortCode || GENERAL_LOTTERY_KEY
+
+    // the listing's own preference order, which is what the columns should
+    // follow.  it is not part of the preference-record query, so that path
+    // still falls back to the order the preferences are defined in.
+    if (bucket.preferenceOrder != null) {
+      orderByShortCode[shortCode] = bucket.preferenceOrder
+    }
     const results = (bucket.preferenceResults || []).map((result) => ({
       lottery_number: result.lotteryNumber,
       unsorted_lottery_rank: result.lotteryRank
@@ -226,13 +234,26 @@ export const massageLotteryBuckets = (buckets) => {
 
   const combinedBuckets = combineVeteranBuckets(Object.entries(resultsByShortCode))
 
+  // a folded column takes its base preference's position, or the veteran
+  // bucket's if that is all the listing has.  anything the API sent without an
+  // order keeps its relative position after the ordered columns.
+  const columnOrder = (shortCode) =>
+    orderByShortCode[shortCode] ?? orderByShortCode[`V-${shortCode}`] ?? Number.MAX_SAFE_INTEGER
+
+  const orderedBuckets = Object.fromEntries(
+    Object.entries(combinedBuckets).sort(
+      ([aShortCode], [bShortCode]) => columnOrder(aShortCode) - columnOrder(bShortCode)
+    )
+  )
+
+  // the general lottery always comes last, after the preference columns
   if (resultsByShortCode[GENERAL_LOTTERY_KEY]) {
-    combinedBuckets[GENERAL_LOTTERY_KEY] = {
+    orderedBuckets[GENERAL_LOTTERY_KEY] = {
       shortCode: GENERAL_LOTTERY_KEY,
       preferenceName: 'General List',
       preferenceResults: resultsByShortCode[GENERAL_LOTTERY_KEY]
     }
   }
 
-  return processUnfilteredBucket(combinedBuckets, unknownResults)
+  return processUnfilteredBucket(orderedBuckets, unknownResults)
 }

--- a/app/javascript/components/lease_ups/lottery_results_page/utils/processLotteryBuckets.js
+++ b/app/javascript/components/lease_ups/lottery_results_page/utils/processLotteryBuckets.js
@@ -99,19 +99,34 @@ export const processUnfilteredBucket = (combinedBuckets, extraResults = []) => {
   return [unfilteredBucket, ...Object.values(combinedBuckets)]
 }
 
+// fold a V-<pref> bucket into its base <pref> bucket: veterans are flagged (the
+// UI marks them with a *) and listed first.  the two sources overlap in the
+// preference-record data, where a veteran holds both a V-COP and a COP record,
+// but the LotteryResult API is not guaranteed to repeat them, so any veteran
+// missing from the base bucket is appended rather than dropped.
 const processVeteranBucket = (bucketApplications, relatedVeteranApplications) => {
   const veteranLotteryNumbers = new Set(
     relatedVeteranApplications.map(({ lottery_number: lotteryNumber }) => lotteryNumber)
   )
   const nonVeteranApplications = []
   const veteranApplications = []
+  const seenVeterans = new Set()
 
   for (const application of bucketApplications) {
     if (veteranLotteryNumbers.has(application.lottery_number)) {
       application.isVeteran = true
       veteranApplications.push(application)
+      seenVeterans.add(application.lottery_number)
     } else {
       nonVeteranApplications.push(application)
+    }
+  }
+
+  for (const application of relatedVeteranApplications) {
+    if (!seenVeterans.has(application.lottery_number)) {
+      application.isVeteran = true
+      veteranApplications.push(application)
+      seenVeterans.add(application.lottery_number)
     }
   }
 
@@ -169,43 +184,48 @@ export const processLotteryBuckets = (applicationPreferences) => {
   return processUnfilteredBucket(combinedBuckets, buckets[UNKNOWN_KEY])
 }
 
+// the LotteryResult API returns one bucket per preference, with the veteran
+// variants kept separate.  reshape its records into the same form the
+// preference-record path produces, then run them through the same combining,
+// so both paths render identical columns.
 export const massageLotteryBuckets = (buckets) => {
-  const massagedBuckets = []
-  const unfilteredResults = []
   const unknownShortCodes = new Set()
+  const unknownResults = []
+  const resultsByShortCode = {}
 
   buckets.forEach((bucket) => {
+    // the general lottery bucket comes back without a short code
     const shortCode = bucket.preferenceShortCode || GENERAL_LOTTERY_KEY
-    const massagedBucket = {
-      shortCode,
-      preferenceResults: []
-    }
+    const results = (bucket.preferenceResults || []).map((result) => ({
+      lottery_number: result.lotteryNumber,
+      unsorted_lottery_rank: result.lotteryRank
+    }))
 
-    if (!Preferences[shortCode]) {
+    if (Preferences[shortCode]) {
+      // a short code can appear more than once if the API ever splits a
+      // preference across buckets, so accumulate rather than overwrite
+      resultsByShortCode[shortCode] = (resultsByShortCode[shortCode] || []).concat(results)
+    } else {
+      // an unmapped preference gets no column of its own, but its applicants
+      // still belong in the unfiltered rank
       unknownShortCodes.add(String(shortCode))
+      unknownResults.push(...results)
     }
-
-    bucket.preferenceResults.forEach((result) => {
-      unfilteredResults.push({
-        lottery_number: result.lotteryNumber,
-        unsorted_lottery_rank: result.lotteryRank
-      })
-      massagedBucket.preferenceResults.push({ lottery_number: result.lotteryNumber })
-    })
-
-    massagedBuckets.push(massagedBucket)
   })
 
   if (unknownShortCodes.size) {
     console.warn(`Unknown lottery preference short code(s): ${[...unknownShortCodes].join(', ')}`)
   }
 
-  return [
-    {
-      preferenceName: 'Unfiltered Rank',
-      preferenceResults: uniqueLotteryNumbers(sortUnfilteredBuckets(unfilteredResults)),
-      shortCode: 'Unfiltered'
-    },
-    ...massagedBuckets
-  ]
+  const combinedBuckets = combineVeteranBuckets(Object.entries(resultsByShortCode))
+
+  if (resultsByShortCode[GENERAL_LOTTERY_KEY]) {
+    combinedBuckets[GENERAL_LOTTERY_KEY] = {
+      shortCode: GENERAL_LOTTERY_KEY,
+      preferenceName: 'General List',
+      preferenceResults: resultsByShortCode[GENERAL_LOTTERY_KEY]
+    }
+  }
+
+  return processUnfilteredBucket(combinedBuckets, unknownResults)
 }

--- a/app/javascript/components/lease_ups/lottery_results_page/utils/processLotteryBuckets.js
+++ b/app/javascript/components/lease_ups/lottery_results_page/utils/processLotteryBuckets.js
@@ -138,7 +138,12 @@ export const combineVeteranBuckets = (buckets) => {
   const combinedBuckets = {}
 
   NonVeteranPreferenceIDs.forEach((bucketKey) => {
-    const bucketApplications = bucketsByKey[bucketKey]
+    const relatedVeteranApplications = bucketsByKey[`V-${bucketKey}`]
+    // the preference-record path seeds every known preference, but the
+    // LotteryResult API returns only the buckets a listing actually has, so a
+    // veteran bucket can arrive without its base bucket.  fall back to an empty
+    // base rather than dropping those applicants from the page entirely
+    const bucketApplications = bucketsByKey[bucketKey] || (relatedVeteranApplications ? [] : null)
 
     if (!bucketApplications) {
       return
@@ -146,11 +151,13 @@ export const combineVeteranBuckets = (buckets) => {
 
     // only ever-present preferences keep an empty column, so that adding a new
     // preference type doesn't add blank columns to every listing's PDF
-    if (!bucketApplications.length && !AlwaysVisiblePreferenceIDs.includes(bucketKey)) {
+    if (
+      !bucketApplications.length &&
+      !relatedVeteranApplications?.length &&
+      !AlwaysVisiblePreferenceIDs.includes(bucketKey)
+    ) {
       return
     }
-
-    const relatedVeteranApplications = bucketsByKey[`V-${bucketKey}`]
 
     combinedBuckets[bucketKey] = {
       shortCode: bucketKey,

--- a/app/javascript/components/lease_ups/lottery_results_page/utils/processLotteryBuckets.js
+++ b/app/javascript/components/lease_ups/lottery_results_page/utils/processLotteryBuckets.js
@@ -1,33 +1,65 @@
-import { Preferences } from './preferences'
+import {
+  AlwaysVisiblePreferenceIDs,
+  LotteryPreferenceIDs,
+  NonVeteranPreferenceIDs,
+  Preferences
+} from './preferences'
 
-const emptyBuckets = {
-  COP: [],
-  'V-COP': [],
-  DTHP: [],
-  'V-DTHP': [],
-  NRHP: [],
-  'V-NRHP': [],
-  L_W: [],
-  'V-L_W': [],
-  generalLottery: []
+const GENERAL_LOTTERY_KEY = 'generalLottery'
+// applications whose preference type we don't recognize are collected here so
+// that they still show up in the Unfiltered Rank column rather than vanishing
+const UNKNOWN_KEY = '__unknown'
+
+// build a fresh set of empty buckets on every call.  these used to be
+// module-level literals that were mutated in place, which leaked results
+// between invocations.
+const buildEmptyBuckets = () => {
+  const buckets = { [GENERAL_LOTTERY_KEY]: [], [UNKNOWN_KEY]: [] }
+
+  LotteryPreferenceIDs.forEach((id) => {
+    buckets[id] = []
+  })
+
+  return buckets
 }
 
 export const groupBuckets = (applicationPreferences) => {
-  return Object.values(applicationPreferences).reduce((acc, appPref) => {
+  const unknownTypes = new Set()
+
+  const buckets = Object.values(applicationPreferences).reduce((acc, appPref) => {
     const cleanApp = {
       lottery_number:
         appPref.application.lottery_number_manual ?? appPref.application.lottery_number,
       unsorted_lottery_rank: appPref.application.unsorted_lottery_rank
     }
+
     if (appPref.application.general_lottery) {
-      acc.generalLottery.push(cleanApp)
+      acc[GENERAL_LOTTERY_KEY].push(cleanApp)
     } else {
-      if (acc[appPref.custom_preference_type]) {
-        acc[appPref.custom_preference_type].push(cleanApp)
+      const preferenceType = appPref.custom_preference_type
+
+      if (acc[preferenceType]) {
+        acc[preferenceType].push(cleanApp)
+      } else {
+        unknownTypes.add(String(preferenceType))
+        acc[UNKNOWN_KEY].push(cleanApp)
       }
     }
+
     return acc
-  }, emptyBuckets)
+  }, buildEmptyBuckets())
+
+  if (unknownTypes.size) {
+    // a new preference type in Salesforce that isn't in preferences.js will end
+    // up here.  it needs to be added there to get its own results column.
+    console.warn(
+      `Unknown lottery preference type(s), omitted from preference columns: ${[
+        ...unknownTypes
+      ].join(', ')}`
+    )
+  }
+
+  return buckets
 }
 
 const sortUnfilteredBuckets = (unfilteredPreferenceResults) => {
@@ -37,97 +69,82 @@ const sortUnfilteredBuckets = (unfilteredPreferenceResults) => {
   return filtered
 }
 
-export const processUnfilteredBucket = (combinedBuckets) => {
-  const unfilteredBucket = {
-    preferenceName: 'Unfiltered Rank',
-    preferenceResults: [],
-    shortCode: 'Unfiltered'
-  }
+const uniqueLotteryNumbers = (results) => {
+  const seen = new Set()
 
-  const combinedPrefResults = combinedBuckets.reduce(
-    (prefResults, bucket) => [...prefResults, ...bucket.preferenceResults],
-    []
-  )
-
-  const uniquePrefResults = combinedPrefResults.reduce((uniqPrefResults, prefResult) => {
-    // find new prefResult in unique pref result
-    const foundMatch = uniqPrefResults.find(
-      (uniqPrefResult) => uniqPrefResult.lottery_number === prefResult.lottery_number
-    )
-
-    if (!foundMatch) {
-      uniqPrefResults.push(prefResult)
+  return results.filter(({ lottery_number: lotteryNumber }) => {
+    if (seen.has(lotteryNumber)) {
+      return false
     }
 
-    return uniqPrefResults
-  }, [])
+    seen.add(lotteryNumber)
 
-  unfilteredBucket.preferenceResults = sortUnfilteredBuckets(uniquePrefResults)
+    return true
+  })
+}
+
+export const processUnfilteredBucket = (combinedBuckets, extraResults = []) => {
+  const combinedPrefResults = Object.values(combinedBuckets).reduce(
+    (prefResults, bucket) => [...prefResults, ...bucket.preferenceResults],
+    [...extraResults]
+  )
+
+  const unfilteredBucket = {
+    preferenceName: 'Unfiltered Rank',
+    preferenceResults: sortUnfilteredBuckets(uniqueLotteryNumbers(combinedPrefResults)),
+    shortCode: 'Unfiltered'
+  }
 
   // put the bucket of unfiltered applicants first
   return [unfilteredBucket, ...Object.values(combinedBuckets)]
 }
 
-const emptyCombinedBuckets = {
-  COP: {
-    shortCode: 'COP',
-    preferenceName: 'COP',
-    preferenceResults: []
-  },
-  DTHP: {
-    shortCode: 'DTHP',
-    preferenceName: 'DTHP',
-    preferenceResults: []
-  },
-  NRHP: {
-    shortCode: 'NRHP',
-    preferenceName: 'NRHP',
-    preferenceResults: []
-  },
-  L_W: {
-    shortCode: 'L_W',
-    preferenceName: 'Live/Work',
-    preferenceResults: []
-  }
-}
-
 const processVeteranBucket = (bucketApplications, relatedVeteranApplications) => {
+  const veteranLotteryNumbers = new Set(
+    relatedVeteranApplications.map(({ lottery_number: lotteryNumber }) => lotteryNumber)
+  )
   const nonVeteranApplications = []
   const veteranApplications = []
+
   for (const application of bucketApplications) {
-    const lotteryNumber = application.lottery_number
-    if (
-      relatedVeteranApplications.find((application) => application.lottery_number === lotteryNumber)
-    ) {
+    if (veteranLotteryNumbers.has(application.lottery_number)) {
       application.isVeteran = true
       veteranApplications.push(application)
     } else {
       nonVeteranApplications.push(application)
     }
   }
+
   return [...veteranApplications, ...nonVeteranApplications]
 }
 
 export const combineVeteranBuckets = (buckets) => {
-  const combinedBuckets = emptyCombinedBuckets
+  const bucketsByKey = Object.fromEntries(buckets)
+  const combinedBuckets = {}
 
-  // shape of bucket is ["bucketKey e.g. COP or V-COP", [array of applications]]
-  for (const [bucketKey, bucketApplications] of buckets) {
-    const bucketInfo = Preferences[bucketKey]
+  NonVeteranPreferenceIDs.forEach((bucketKey) => {
+    const bucketApplications = bucketsByKey[bucketKey]
 
-    if (bucketKey !== 'generalLottery' && !bucketInfo.isVeteran) {
-      const relatedVeteranBucket = buckets.find((bucket) => bucket[0] === `V-${bucketKey}`)
-
-      if (relatedVeteranBucket) {
-        combinedBuckets[bucketKey].preferenceResults = processVeteranBucket(
-          bucketApplications,
-          relatedVeteranBucket[1]
-        )
-      } else {
-        combinedBuckets[bucketKey].preferenceResults = bucketApplications
-      }
+    if (!bucketApplications) {
+      return
     }
-  }
+
+    // only ever-present preferences keep an empty column, so that adding a new
+    // preference type doesn't add blank columns to every listing's PDF
+    if (!bucketApplications.length && !AlwaysVisiblePreferenceIDs.includes(bucketKey)) {
+      return
+    }
+
+    const relatedVeteranApplications = bucketsByKey[`V-${bucketKey}`]
+
+    combinedBuckets[bucketKey] = {
+      shortCode: bucketKey,
+      preferenceName: Preferences[bucketKey].shortName,
+      preferenceResults: relatedVeteranApplications
+        ? processVeteranBucket(bucketApplications, relatedVeteranApplications)
+        : bucketApplications
+    }
+  })
 
   return combinedBuckets
 }
@@ -140,37 +157,34 @@ export const processLotteryBuckets = (applicationPreferences) => {
   const combinedBuckets = combineVeteranBuckets(Object.entries(buckets))
 
   // add general lottery bucket
-  if (buckets.generalLottery) {
-    combinedBuckets.generalLottery = {
-      shortCode: 'generalLottery',
+  if (buckets[GENERAL_LOTTERY_KEY]) {
+    combinedBuckets[GENERAL_LOTTERY_KEY] = {
+      shortCode: GENERAL_LOTTERY_KEY,
       preferenceName: 'General List',
-      preferenceResults: buckets.generalLottery
+      preferenceResults: buckets[GENERAL_LOTTERY_KEY]
     }
   }
 
-  // add the unfiltered bucket
-  const processedBuckets = processUnfilteredBucket(Object.values(combinedBuckets))
-
-  return processedBuckets
+  // add the unfiltered bucket, including any applications we couldn't bucket
+  return processUnfilteredBucket(combinedBuckets, buckets[UNKNOWN_KEY])
 }
-
-const uniqueLotteryNumbers = (results) =>
-  results.reduce(
-    (results, result) =>
-      results.find((r) => r.lottery_number === result.lottery_number)
-        ? results
-        : [...results, result],
-    []
-  )
 
 export const massageLotteryBuckets = (buckets) => {
   const massagedBuckets = []
   const unfilteredResults = []
+  const unknownShortCodes = new Set()
+
   buckets.forEach((bucket) => {
+    const shortCode = bucket.preferenceShortCode || GENERAL_LOTTERY_KEY
     const massagedBucket = {
-      shortCode: bucket.preferenceShortCode || 'generalLottery',
+      shortCode,
       preferenceResults: []
     }
+
+    if (!Preferences[shortCode]) {
+      unknownShortCodes.add(String(shortCode))
+    }
+
     bucket.preferenceResults.forEach((result) => {
       unfilteredResults.push({
         lottery_number: result.lotteryNumber,
@@ -178,8 +192,13 @@ export const massageLotteryBuckets = (buckets) => {
       })
       massagedBucket.preferenceResults.push({ lottery_number: result.lotteryNumber })
     })
+
     massagedBuckets.push(massagedBucket)
   })
+
+  if (unknownShortCodes.size) {
+    console.warn(`Unknown lottery preference short code(s): ${[...unknownShortCodes].join(', ')}`)
+  }
 
   return [
     {

--- a/spec/javascript/components/lottery_results_page/processLotteryBuckets.test.js
+++ b/spec/javascript/components/lottery_results_page/processLotteryBuckets.test.js
@@ -67,6 +67,34 @@ describe('Process Lottery Buckets', () => {
       ])
     })
 
+    test('it should keep veterans when the API omits the base preference bucket', () => {
+      const [unfiltered, ...buckets] = massageLotteryBuckets([
+        {
+          preferenceShortCode: 'V-COP',
+          preferenceResults: [{ lotteryNumber: 'veteran', lotteryRank: 1 }]
+        }
+      ])
+
+      expect(buckets.map((bucket) => bucket.shortCode)).toEqual(['COP'])
+      expect(buckets[0].preferenceResults).toEqual([
+        { lottery_number: 'veteran', unsorted_lottery_rank: 1, isVeteran: true }
+      ])
+      expect(unfiltered.preferenceResults).toEqual([
+        { lottery_number: 'veteran', unsorted_lottery_rank: 1, isVeteran: true }
+      ])
+    })
+
+    test('it should not add a column for a preference the listing does not have', () => {
+      const [, ...buckets] = massageLotteryBuckets([
+        {
+          preferenceShortCode: 'DTHP',
+          preferenceResults: [{ lotteryNumber: 'one', lotteryRank: 1 }]
+        }
+      ])
+
+      expect(buckets.map((bucket) => bucket.shortCode)).toEqual(['DTHP'])
+    })
+
     test('it should keep applicants from an unmapped preference in the unfiltered rank', () => {
       const [unfiltered, ...buckets] = massageLotteryBuckets([
         {

--- a/spec/javascript/components/lottery_results_page/processLotteryBuckets.test.js
+++ b/spec/javascript/components/lottery_results_page/processLotteryBuckets.test.js
@@ -226,16 +226,91 @@ describe('Process Lottery Buckets', () => {
     })
 
     test('it should keep applicants from an unmapped preference in the unfiltered rank', () => {
-      const [unfiltered, ...buckets] = massageLotteryBuckets([
-        {
-          preferenceShortCode: 'NOT_A_REAL_PREFERENCE',
-          preferenceResults: [{ lotteryNumber: 'orphan', lotteryRank: 1 }]
-        }
-      ])
+      const warnings = []
+      const [unfiltered, ...buckets] = massageLotteryBuckets(
+        [
+          {
+            preferenceShortCode: 'NOT_A_REAL_PREFERENCE',
+            preferenceResults: [
+              { lotteryNumber: 'orphan', lotteryRank: 1 },
+              { lotteryNumber: 'orphan-two', lotteryRank: 2 }
+            ]
+          }
+        ],
+        warnings
+      )
 
       expect(buckets).toEqual([])
-      expect(unfiltered.preferenceResults).toEqual([
-        { lottery_number: 'orphan', unsorted_lottery_rank: 1 }
+      expect(unfiltered.preferenceResults).toHaveLength(2)
+      expect(warnings).toEqual([
+        "“NOT_A_REAL_PREFERENCE” isn't a preference this page can display, so its 2 applications " +
+          'appear only in the Unfiltered Rank column.'
+      ])
+    })
+  })
+
+  describe('warnings', () => {
+    // every warning also goes to the console, which would otherwise be noise
+    let consoleWarn
+
+    beforeEach(() => {
+      consoleWarn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+
+    afterEach(() => consoleWarn.mockRestore())
+
+    const veteranBuckets = (baseResults) => [
+      {
+        preferenceShortCode: 'V-DTHP',
+        preferenceResults: [{ lotteryNumber: 'vet', lotteryRank: 1 }]
+      },
+      { preferenceShortCode: 'DTHP', preferenceResults: baseResults }
+    ]
+
+    test('it should warn when a veteran has no matching base preference', () => {
+      const warnings = []
+
+      massageLotteryBuckets(
+        veteranBuckets([{ lotteryNumber: 'someone-else', lotteryRank: 2 }]),
+        warnings
+      )
+
+      expect(warnings).toEqual([
+        '1 application has the veteran version of Displaced Tenant Housing Preference (DTHP) but ' +
+          "not the preference itself, which shouldn't happen. It's included in the DTHP column, " +
+          'but the application data may need to be checked.'
+      ])
+    })
+
+    test('it should not warn when the veteran data lines up', () => {
+      const warnings = []
+
+      massageLotteryBuckets(veteranBuckets([{ lotteryNumber: 'vet', lotteryRank: 1 }]), warnings)
+
+      expect(warnings).toEqual([])
+    })
+
+    test('it should collect warnings from the preference-record path too', () => {
+      const warnings = []
+
+      processLotteryBuckets(
+        [
+          {
+            application: {
+              general_lottery: false,
+              lottery_number: 'orphan',
+              lottery_number_manual: null,
+              unsorted_lottery_rank: 1
+            },
+            custom_preference_type: 'NOT_A_REAL_PREFERENCE'
+          }
+        ],
+        warnings
+      )
+
+      expect(warnings).toEqual([
+        "“NOT_A_REAL_PREFERENCE” isn't a preference this page can display, so its 1 application " +
+          'appears only in the Unfiltered Rank column.'
       ])
     })
   })

--- a/spec/javascript/components/lottery_results_page/processLotteryBuckets.test.js
+++ b/spec/javascript/components/lottery_results_page/processLotteryBuckets.test.js
@@ -167,6 +167,53 @@ describe('Process Lottery Buckets', () => {
       expect(buckets.find((bucket) => bucket.shortCode === 'COP').preferenceResults).toEqual([])
     })
 
+    test("it should order columns by the listing's preference order", () => {
+      const bucket = (preferenceShortCode, preferenceOrder) => ({
+        preferenceShortCode,
+        preferenceOrder,
+        preferenceResults: [{ lotteryNumber: preferenceShortCode, lotteryRank: preferenceOrder }]
+      })
+
+      // the order Salesforce reports, which does not match the order the
+      // preferences happen to be defined in
+      const buckets = massageLotteryBuckets([
+        bucket('RTR-H', 1),
+        bucket('V-COP', 2),
+        bucket('COP', 3),
+        bucket('RB_AHP', 4),
+        bucket('V-DTHP', 5),
+        bucket('DTHP', 6),
+        { preferenceShortCode: null, preferenceResults: [{ lotteryNumber: 'g', lotteryRank: 7 }] }
+      ])
+
+      // unfiltered first, general lottery last, preference columns in between
+      expect(buckets.map((b) => b.shortCode)).toEqual([
+        'Unfiltered',
+        'RTR-H',
+        'COP',
+        'RB_AHP',
+        'DTHP',
+        'generalLottery'
+      ])
+    })
+
+    test('it should position a folded column by its veteran bucket when that is all there is', () => {
+      const buckets = massageLotteryBuckets([
+        {
+          preferenceShortCode: 'V-DTHP',
+          preferenceOrder: 1,
+          preferenceResults: [{ lotteryNumber: 'vet', lotteryRank: 1 }]
+        },
+        {
+          preferenceShortCode: 'COP',
+          preferenceOrder: 2,
+          preferenceResults: [{ lotteryNumber: 'cop', lotteryRank: 2 }]
+        }
+      ])
+
+      expect(buckets.map((b) => b.shortCode)).toEqual(['Unfiltered', 'DTHP', 'COP'])
+    })
+
     test('it should give Right to Return its own column', () => {
       const [, ...buckets] = massageLotteryBuckets([
         {

--- a/spec/javascript/components/lottery_results_page/processLotteryBuckets.test.js
+++ b/spec/javascript/components/lottery_results_page/processLotteryBuckets.test.js
@@ -11,6 +11,74 @@ describe('Process Lottery Buckets', () => {
     test('it should return the correct data when combineGroups is true', () => {
       expect(processLotteryBuckets(testBuckets)).toEqual(testBucketResults)
     })
+
+    const preferenceRecord = ({
+      type,
+      lotteryNumber,
+      rank,
+      generalLottery = false,
+      manual = null
+    }) => ({
+      application: {
+        general_lottery: generalLottery,
+        general_lottery_rank: generalLottery ? rank : null,
+        lottery_number: lotteryNumber,
+        lottery_number_manual: manual,
+        unsorted_lottery_rank: rank
+      },
+      custom_preference_type: type,
+      record_type_for_app_preferences: type
+    })
+
+    test('it should put general lottery applicants in their own bucket', () => {
+      const buckets = processLotteryBuckets([
+        preferenceRecord({ type: 'COP', lotteryNumber: 'pref', rank: 1 }),
+        preferenceRecord({ type: 'L_W', lotteryNumber: 'general', rank: 2, generalLottery: true })
+      ])
+      const general = buckets.find((bucket) => bucket.shortCode === 'generalLottery')
+
+      expect(general.preferenceResults).toEqual([
+        { lottery_number: 'general', unsorted_lottery_rank: 2 }
+      ])
+      // the general lottery applicant belongs to no preference column
+      expect(buckets.find((bucket) => bucket.shortCode === 'COP').preferenceResults).toEqual([
+        { lottery_number: 'pref', unsorted_lottery_rank: 1 }
+      ])
+    })
+
+    test('it should prefer a manually assigned lottery number', () => {
+      const buckets = processLotteryBuckets([
+        preferenceRecord({ type: 'COP', lotteryNumber: 'auto', rank: 1, manual: 'manual' })
+      ])
+
+      expect(buckets.find((bucket) => bucket.shortCode === 'COP').preferenceResults).toEqual([
+        { lottery_number: 'manual', unsorted_lottery_rank: 1 }
+      ])
+    })
+
+    test('it should keep applicants from an unmapped preference in the unfiltered rank', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const [unfiltered, ...buckets] = processLotteryBuckets([
+        preferenceRecord({ type: 'NOT_A_REAL_PREFERENCE', lotteryNumber: 'orphan', rank: 1 })
+      ])
+
+      // no column of its own, but the applicant is not lost
+      expect(buckets.map((bucket) => bucket.shortCode)).toEqual([
+        'COP',
+        'DTHP',
+        'NRHP',
+        'L_W',
+        'generalLottery'
+      ])
+      expect(buckets.every((bucket) => !bucket.preferenceResults.length)).toBe(true)
+      expect(unfiltered.preferenceResults).toEqual([
+        { lottery_number: 'orphan', unsorted_lottery_rank: 1 }
+      ])
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('NOT_A_REAL_PREFERENCE'))
+
+      warn.mockRestore()
+    })
   })
 
   describe('massageLotteryBuckets', () => {
@@ -89,10 +157,14 @@ describe('Process Lottery Buckets', () => {
         {
           preferenceShortCode: 'DTHP',
           preferenceResults: [{ lotteryNumber: 'one', lotteryRank: 1 }]
-        }
+        },
+        // an always-visible preference still gets its empty column, even if the
+        // API sends the bucket without any results array at all
+        { preferenceShortCode: 'COP' }
       ])
 
-      expect(buckets.map((bucket) => bucket.shortCode)).toEqual(['DTHP'])
+      expect(buckets.map((bucket) => bucket.shortCode)).toEqual(['COP', 'DTHP'])
+      expect(buckets.find((bucket) => bucket.shortCode === 'COP').preferenceResults).toEqual([])
     })
 
     test('it should give Right to Return its own column', () => {

--- a/spec/javascript/components/lottery_results_page/processLotteryBuckets.test.js
+++ b/spec/javascript/components/lottery_results_page/processLotteryBuckets.test.js
@@ -22,5 +22,63 @@ describe('Process Lottery Buckets', () => {
       )
       expect(massagedBuckets.find((bucket) => bucket.shortCode === 'Unfiltered')).toBeTruthy()
     })
+
+    test('it should fold veteran buckets into their base preference', () => {
+      const [unfiltered, ...buckets] = massageLotteryBuckets([
+        {
+          preferenceShortCode: 'V-COP',
+          preferenceResults: [
+            { lotteryNumber: 'shared', lotteryRank: 1 },
+            { lotteryNumber: 'veteran-only', lotteryRank: 9 }
+          ]
+        },
+        {
+          preferenceShortCode: 'COP',
+          preferenceResults: [
+            { lotteryNumber: 'shared', lotteryRank: 1 },
+            { lotteryNumber: 'non-veteran', lotteryRank: 2 }
+          ]
+        },
+        {
+          preferenceShortCode: null,
+          preferenceResults: [{ lotteryNumber: 'general', lotteryRank: 3 }]
+        }
+      ])
+
+      // no V- column of its own
+      expect(buckets.map((bucket) => bucket.shortCode)).toEqual(['COP', 'generalLottery'])
+
+      const cop = buckets.find((bucket) => bucket.shortCode === 'COP')
+
+      // veterans first, flagged for the * the results table renders, and a
+      // veteran the API didn't repeat in the base bucket is still listed
+      expect(cop.preferenceResults).toEqual([
+        { lottery_number: 'shared', unsorted_lottery_rank: 1, isVeteran: true },
+        { lottery_number: 'veteran-only', unsorted_lottery_rank: 9, isVeteran: true },
+        { lottery_number: 'non-veteran', unsorted_lottery_rank: 2 }
+      ])
+
+      // unfiltered rank holds every applicant once, in lottery rank order
+      expect(unfiltered.preferenceResults.map(({ lottery_number: n }) => n)).toEqual([
+        'shared',
+        'non-veteran',
+        'general',
+        'veteran-only'
+      ])
+    })
+
+    test('it should keep applicants from an unmapped preference in the unfiltered rank', () => {
+      const [unfiltered, ...buckets] = massageLotteryBuckets([
+        {
+          preferenceShortCode: 'NOT_A_REAL_PREFERENCE',
+          preferenceResults: [{ lotteryNumber: 'orphan', lotteryRank: 1 }]
+        }
+      ])
+
+      expect(buckets).toEqual([])
+      expect(unfiltered.preferenceResults).toEqual([
+        { lottery_number: 'orphan', unsorted_lottery_rank: 1 }
+      ])
+    })
   })
 })

--- a/spec/javascript/components/lottery_results_page/processLotteryBuckets.test.js
+++ b/spec/javascript/components/lottery_results_page/processLotteryBuckets.test.js
@@ -95,6 +95,17 @@ describe('Process Lottery Buckets', () => {
       expect(buckets.map((bucket) => bucket.shortCode)).toEqual(['DTHP'])
     })
 
+    test('it should give Right to Return its own column', () => {
+      const [, ...buckets] = massageLotteryBuckets([
+        {
+          preferenceShortCode: 'RTR-H',
+          preferenceResults: [{ lotteryNumber: 'one', lotteryRank: 1 }]
+        }
+      ])
+
+      expect(buckets.map((bucket) => bucket.shortCode)).toEqual(['RTR-H'])
+    })
+
     test('it should keep applicants from an unmapped preference in the unfiltered rank', () => {
       const [unfiltered, ...buckets] = massageLotteryBuckets([
         {


### PR DESCRIPTION
## Description

The lottery results page now uses the LotteryResult API by default, so listings like Notre Dame show every applicant instead of only those receiving a preference. Veterans are folded into their base preference column and marked with a `*`, columns follow the listing's own preference order, and anything the page can't display is called out in an on-screen warning.

## Jira ticket

https://sfgovdt.jira.com/browse/DAH-3752

## What was wrong

The plain `/listings/<id>/lottery-results` URL used the older preference-record SOQL query, whose `WHERE` clause only matches applications that actually receive a preference. For Notre Dame that returned 17 records (5 COP, 12 DTHP) out of ~4000 applications, with the general lottery bucket empty. The LotteryResult API returns every bucket, but since #733 it was reachable only by appending `?withLotteryResultApi`.

Notre Dame is hit hardest because it has no Live/Work preference: the legacy query only picks up general-lottery applicants through an `L_W` clause, so on a listing without that preference they vanish entirely.

## Review instructions

Applies to any environment with real lottery data.

1. Go to `/listings/a0W7y000004QBvBEAW/lottery-results` (Notre Dame). Unfiltered Rank should list ~4015 lottery numbers, with a General List column of ~3998 alongside COP (5) and DTHP (12).
2. Append `?legacy`. The old behavior should return: 17 numbers, no General List column.
3. Go to `/listings/a0W7y00000HayVJEAZ/lottery-results` and compare against `?legacy`. Counts should match the table above, including veterans at the top of COP, DTHP and Live/Work marked with a `*`.
4. Narrow the browser window until the Live/Work subtitle wraps to three or four lines. The results below it should move down, not be printed over.
5. Save the results to PDF from that page. The warnings banner, if the listing shows one, should not appear in the PDF.

All five have been performed against production data.

**848 Fairfax results in [current partners](https://partner.housing.sfgov.org/listings/a0W7y00000HayVJEAZ/lottery-results):**
<img width="1371" height="502" alt="image" src="https://github.com/user-attachments/assets/0def7953-01b2-4910-9683-55c4c9b89167" />

**On this PR:**
<img width="1371" height="502" alt="image" src="https://github.com/user-attachments/assets/ec022593-ffda-4b03-a0fc-5f6d8060e56f" />

Note that the PR includes the listing's preferences in the correct order, while current partners is missing them.

--- 

<details><summary><b>Additional details</b></summary>
<p>
## Commits

**The fix**

- **`3fd280a9`** — an unmapped preference short code used to throw in `LotteryBuckets` and blank the whole page. It now skips just that column and warns. `preferences.js` was also missing `ADHP`, `RB_AHP`, `AG` and `Custom` (plus veteran variants), which exist in `Force::Preference` — those were a live cause of the blanking, on both data paths.
- **`647f429a`** — flips the default to the LotteryResult API. That API keeps veteran buckets separate, so its records are now reshaped and run through the same `combineVeteranBuckets` / `processUnfilteredBucket` as the preference-record path, giving both paths identical column logic.
- **`9783e8c6`** — `combineVeteranBuckets` dropped applicants when a `V-` bucket arrived without its base bucket. The legacy path seeds every known preference so this could not happen there, but the API returns only the buckets a listing has. (Thanks Copilot.)

**Found while verifying against real data**

- **`e4241e20`** — `RTR-H` (Right to Return - Hunters View) was missing from the preference definitions, so its 20 applicants on `a0W7y00000HayVJEAZ` got no column on *either* path. Surfaced by the unmapped-short-code warning added in the first commit.
- **`bb7b8021`** — columns now follow the `preferenceOrder` the API reports for each bucket, which is the order the listing's preferences are configured in. They were following the order preferences happen to be defined in `preferences.js`, which was right by intent but predated the rarer preferences, so `RB_AHP` sorted last instead of third. A folded veteran column takes its base preference's position. The preference-record query doesn't select `Preference_Order__c`, so that path keeps the defined order.
- **`8e0373a7`** — the warnings only ever reached the browser console, where the housing team will never see them. They now also render in a banner above the results, together with a new warning for veteran applications that have no matching base preference record, which shouldn't happen and points at a data problem. The banner sits outside the printed component and is hidden in print styles, since a warning can be expected for a given listing and known to be ignorable.
- **`5bafe5ad`** — RTR, RB/AHP, ADHP, AG, DFR, DSE and Custom had no subtitle, so they printed without one. None sets units aside, so they all get "Up to 100% of units" (still editable per listing). Those subtitles wrap on a narrow column, and the title and subtitle had fixed heights that a wrapped line overflowed, printing over the first lottery numbers — they're grid with `min-height` now, so the row grows instead.

**Tests**

- **`6e93e137`** — coverage for the preference-record grouping branches (general lottery, manual lottery numbers, unmapped types), which the existing fixture never exercised.

`?legacy` is left as a temporary escape hatch to the old query for comparison. It and the `use_lottery_result_api` plumbing can be deleted once we're confident; nothing else calls either.

## Verification against real data

Compared both paths on `a0W7y00000HayVJEAZ`, which has veteran applicants in three preferences. They agree exactly — same counts, same veteran flags, and identical lottery-number ordering within every shared column. Unfiltered Rank is 2389 on both, matching the distinct applicant count in the payload.

| | Unfiltered | RTR | COP | RB/AHP | DTHP | Live/Work | NRHP | General |
|---|---|---|---|---|---|---|---|---|
| API | 2389 | 20 | 37 (1 vet) | 247 | 10 (1 vet) | 1952 (9 vets) | — | 374 |
| `?legacy` | 2389 | 20 | 37 (1 vet) | 247 | 10 (1 vet) | 1952 (9 vets) | 0 | 374 |

Two differences, both expected:

- The API orders columns by the listing's preference order, putting RB/AHP third; the legacy path has no such field and falls back to the defined order, which puts it after Live/Work.
- The empty `NRHP` column exists only under `?legacy`, because `AlwaysVisiblePreferenceIDs` pre-seeds every known preference there, whereas the API returns only the preferences a listing actually has. That is the same mechanism that gave Notre Dame empty columns it should not have had.

Also worth noting: on this listing the API repeats each veteran in the base bucket, so the folding matches the legacy assumption. The veteran-only fallback in `9783e8c6` is a safety net that no observed data triggers — per housing, a `V-` preference without its base preference on the same application is a data problem, which is why it now warns rather than passing silently.

Layout was checked in the browser at 1400px, 1280px and 700px on this listing (seven columns): titles bottom-align, no subtitle overflows its cell, and every column's first lottery number starts at the same height.

## Tests

`spec/javascript/components/lottery_results_page/processLotteryBuckets.test.js` covers veteran folding (shared, veteran-only, and missing-base-bucket cases), column ordering, unmapped short codes reaching the unfiltered rank, Right to Return, the legacy grouping branches, and the warnings — including that none is raised when the veteran data does line up. Line coverage for `processLotteryBuckets.js` is 100%. Full JS suite passes apart from a `ListingsPage` snapshot that fails identically on `main`.
</p>
</details> 

