### PR TITLE
fix: DAH-0000 enable local dev on Windows

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,3 +11,6 @@ UNLEASH_URL=
 # backend
 DAHLIA_API_KEY=
 DAHLIA_API_URL=
+
+# Windows only: set to 0 to disable Puma worker forking (not supported on Windows)
+# PUMA_WORKERS=0

--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ gem 'rails_12factor', group: :production
 gem 'sentry-ruby'
 gem "sentry-rails"
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-# gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem "devise", "~> 5.0.4"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,6 +145,7 @@ GEM
     ffi (1.17.3-aarch64-linux-gnu)
     ffi (1.17.3-aarch64-linux-musl)
     ffi (1.17.3-arm64-darwin)
+    ffi (1.17.3-x64-mingw-ucrt)
     ffi (1.17.3-x86_64-darwin)
     ffi (1.17.3-x86_64-linux-gnu)
     ffi (1.17.3-x86_64-linux-musl)
@@ -231,6 +232,8 @@ GEM
     nokogiri (1.19.4-aarch64-linux-musl)
       racc (~> 1.4)
     nokogiri (1.19.4-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x64-mingw-ucrt)
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-darwin)
       racc (~> 1.4)
@@ -470,6 +473,7 @@ GEM
     sqlite3 (2.9.5-aarch64-linux-gnu)
     sqlite3 (2.9.5-aarch64-linux-musl)
     sqlite3 (2.9.5-arm64-darwin)
+    sqlite3 (2.9.5-x64-mingw-ucrt)
     sqlite3 (2.9.5-x86_64-darwin)
     sqlite3 (2.9.5-x86_64-linux-gnu)
     sqlite3 (2.9.5-x86_64-linux-musl)
@@ -481,6 +485,8 @@ GEM
     timeout (0.6.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2026.3)
+      tzinfo (>= 1.0.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
@@ -518,6 +524,8 @@ GEM
       ffi (~> 1.17.2)
     yggdrasil-engine (1.2.2-arm64-darwin)
       ffi (~> 1.17.2)
+    yggdrasil-engine (1.2.2-x64-mingw-ucrt)
+      ffi (~> 1.17.2)
     yggdrasil-engine (1.2.2-x86_64-darwin)
       ffi (~> 1.17.2)
     yggdrasil-engine (1.2.2-x86_64-linux)
@@ -530,6 +538,7 @@ PLATFORMS
   aarch64-linux-gnu
   aarch64-linux-musl
   arm64-darwin
+  x64-mingw-ucrt
   x86_64-darwin
   x86_64-linux-gnu
   x86_64-linux-musl
@@ -582,6 +591,7 @@ DEPENDENCIES
   sprockets-rails
   sqlite3 (>= 2.1)
   terser
+  tzinfo-data
   unleash (~> 6.6)
   vcr
   web-console (>= 3.3.0)

--- a/config/database.yml
+++ b/config/database.yml
@@ -6,8 +6,11 @@
 #
 default: &default
   adapter: sqlite3
-  # Total concurrent connections = workers * threads
-  pool: <%= (ENV.fetch("PUMA_WORKERS", 2).to_i) * (ENV.fetch("PUMA_THREADS", 3).to_i) %>
+  # Total concurrent connections = processes * threads.
+  # PUMA_WORKERS=0 means Puma runs in single mode (one process), not zero
+  # processes, so treat 0 the same as 1 here (e.g. on Windows, which doesn't
+  # support Puma's clustered/forked worker mode).
+  pool: <%= [ENV.fetch("PUMA_WORKERS", 2).to_i, 1].max * (ENV.fetch("PUMA_THREADS", 3).to_i) %>
   timeout: 5000
 
 development:

--- a/config/shakapacker.yml
+++ b/config/shakapacker.yml
@@ -44,6 +44,13 @@ development:
     headers:
       'Access-Control-Allow-Origin': '*'
     static:
+      # Windows workaround: shakapacker's webpackDevServerConfig.js sets
+      # static.publicPath to the absolute filesystem output path (contentBase)
+      # instead of a URL path. On Windows the backslashes in that path break
+      # path-to-regexp when webpack-dev-server registers it as an Express route
+      # (see D:\...\public\packs -> "Missing parameter name at index 2").
+      # Overriding it here with the correct URL path avoids that crash.
+      publicPath: '/packs/'
       watch:
         ignored: '**/node_modules/**'
 

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "lint": "eslint --ext .js,.jsx app/ spec/",
     "lint:fix": "eslint --fix --ext .js,.jsx app/ spec/",
     "rails-server": "rails s",
-    "webpack-hot": "bin/shakapacker-dev-server --hot",
+    "webpack-hot": "ruby bin/shakapacker-dev-server --hot",
     "start": "npm-run-all -p -l webpack-hot rails-server",
     "print_release_info": "bash $PWD/print_release_info.sh",
     "create_release_branch": "bash $PWD/create_release_branch.sh",


### PR DESCRIPTION
## Description

Four small changes that let the app run for local development on Windows. No application code is touched, and nothing here changes behavior on macOS or Linux.

## Jira ticket

DAH-000 — developer environment setup, no ticket.

## The changes

- **`package.json`** — run `bin/shakapacker-dev-server` through `ruby` explicitly. Windows `cmd.exe` can't execute a Ruby shebang script directly.
- **`Gemfile`** — uncomment `tzinfo-data` for the Windows platforms. Windows ships no system zoneinfo database, and the gem is already platform-gated, so it isn't installed anywhere else.
- **`config/shakapacker.yml`** — pin `dev_server.static.publicPath` to `/packs/` in the `development` block. Shakapacker's `webpackDevServerConfig.js` assigns the absolute filesystem output path there rather than a URL path; on Windows the backslashes break `path-to-regexp` when webpack-dev-server registers it as an Express route (`Missing parameter name at index 2`).
- **`config/database.yml`** — treat `PUMA_WORKERS=0` as one process when sizing the connection pool. Puma's clustered mode isn't supported on Windows, so single mode is set with `PUMA_WORKERS=0`, which meant a pool of `0 * threads = 0`.
- **`.env.sample`** — document the `PUMA_WORKERS=0` workaround, commented out.

## Risk

The `database.yml` change is the only one that isn't Windows- or development-scoped, so it's the one worth a careful look. It computes `max(PUMA_WORKERS, 1) * PUMA_THREADS` instead of `PUMA_WORKERS * PUMA_THREADS`, which is identical for every value of 1 or higher — it only differs when the variable is explicitly set to `0`, where the old expression produced a pool of zero connections. The default of `2` is unaffected.

The shakapacker override is inside the `development:` block only. The `tzinfo-data` gem is gated to `mingw`/`mswin`/`x64_mingw`/`jruby` platforms and does not install on macOS or Linux; `Gemfile.lock` gains the platform-specific entries.

## Review instructions

Applies to local development only; nothing to check in a deployed environment.

- On macOS or Linux: `bundle install && npm start` should behave exactly as before. That is the real test here — that this is a no-op off Windows.
- On Windows: with `PUMA_WORKERS=0` set in `.env`, `npm start` should boot both the Rails server and the webpack dev server, and the app should load.

Performed on Windows 11 (the branch is what this environment is currently running on). Not re-verified on macOS or Linux — worth a second pair of eyes from someone on either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
